### PR TITLE
Add basic collection ccache APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.2.0 - TBD
+
+* Added [krb5_cc_switch](https://web.mit.edu/kerberos/krb5-1.11/doc/appdev/refs/api/krb5_cc_switch.html)
+  * Used to switch the primary credential cache in a collection credential cache
+* Added [krb5_cc_support_switch](https://github.com/heimdal/heimdal/blob/9dcab76724b417140b4e475701118a01d2892e7c/lib/krb5/cache.c)
+  * Used to detect if a credential cache type, like `FILE`, `DIR`, supports switching with `krb5_cc_switch`
+* Added [krb5_cc_cache_match](https://web.mit.edu/kerberos/krb5-1.11/doc/appdev/refs/api/krb5_cc_cache_match.html)
+  * Retrieve the credential cache inside a collection for the principal specified
+
+
 ## 0.1.2 - 2021-10-06
 
 * Added Python 3.10 wheels

--- a/setup.py
+++ b/setup.py
@@ -295,7 +295,7 @@ class sdist_krb5(sdist):
 
 setup(
     name="krb5",
-    version="0.1.2",
+    version="0.2.0",
     packages=find_packages(where="src"),
     package_data={
         "krb5": ["py.typed", "*.pyi"],

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -3,6 +3,7 @@
 
 from krb5._ccache import (
     CCache,
+    cc_cache_match,
     cc_default,
     cc_default_name,
     cc_destroy,
@@ -13,6 +14,8 @@ from krb5._ccache import (
     cc_new_unique,
     cc_resolve,
     cc_store_cred,
+    cc_support_switch,
+    cc_switch,
 )
 from krb5._context import Context, get_default_realm, init_context, set_default_realm
 from krb5._creds import (
@@ -62,6 +65,7 @@ __all__ = [
     "Principal",
     "PrincipalParseFlags",
     "PrincipalUnparseFlags",
+    "cc_cache_match",
     "cc_default",
     "cc_default_name",
     "cc_destroy",
@@ -72,6 +76,8 @@ __all__ = [
     "cc_new_unique",
     "cc_resolve",
     "cc_store_cred",
+    "cc_support_switch",
+    "cc_switch",
     "get_default_realm",
     "get_init_creds_keytab",
     "get_init_creds_opt_alloc",

--- a/src/krb5/_ccache.pyi
+++ b/src/krb5/_ccache.pyi
@@ -29,6 +29,23 @@ class CCache:
     def cache_type(self) -> typing.Optional[bytes]:
         """The type of the credential cache."""
 
+def cc_cache_match(
+    context: Context,
+    principal: Principal,
+) -> CCache:
+    """Find a credential cache for the specified principal.
+
+    Find a cache within the collection whose default principal is the same as
+    the one specified.
+
+    Args:
+        context: Krb5 context.
+        principal: The principal to find in the collection cache.
+
+    Returns:
+        CCache: The opened credential cache for the principal specified.
+    """
+
 def cc_default(
     context: Context,
 ) -> CCache:
@@ -188,4 +205,36 @@ def cc_store_cred(
         context: Krb5 context.
         cache: The credential cache to store the creds into.
         creds: The credentials to store.
+    """
+
+def cc_support_switch(
+    context: Context,
+    cache_type: bytes,
+) -> bool:
+    """Check whether the cache type supports switching.
+
+    Checks whether the credential cache type specified supports switching the
+    primary cache in its colleciton using :meth:`cc_switch`.
+
+    Args:
+        context: Krb5 context.
+        cache_type: The credential cache type, like ``FILE``, ``DIR``, etc to
+            check whether it supports switching or not.
+
+    Returns:
+        bool: The cache type supports switching.
+    """
+
+def cc_switch(
+    context: Context,
+    cache: CCache,
+) -> None:
+    """Switch primary cache in a collection.
+
+    If the type of cache supports it, set the cache to be the primary
+    credential cache for the collection it belongs to.
+
+    Args:
+        context: Krb5 context.
+        cache: The credential cache to set as the primary in its collection.
     """


### PR DESCRIPTION
Adds the krb5_cc_switch, krb5_cc_support_switch, and krb5_cc_cache_match
APIs to support finding and swaping the credential cache used in a
collection of caches like DIR.

Fixes https://github.com/jborean93/pykrb5/issues/6