### PR TITLE
Add keytab management functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,6 @@
         "-vv"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
     "python.testing.pytestEnabled": true,
     "[python]": {
         "editor.codeActionsOnSave": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.3.0 - TBD
+
+* Added Keytab management APIs:
+  * [krb5_kt_add_entry](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_kt_add_entry.html)
+  * [krb5_kt_get_entry](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_kt_get_entry.html)
+  * [krb5_kt_have_content](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_kt_have_content.html)
+  * [krb5_kt_read_service_key](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_kt_read_service_key.html)
+  * [krb5_kt_remove_entry](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_kt_remove_entry.html)
+  * [krb5_kt_start_seq_get](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_kt_start_seq_get.html)
+  * [krb5_kt_next_entry](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_kt_next_entry.html)
+  * [krb5_kt_end_seq_get](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_kt_end_seq_get.html)
+* Keytabs can be iterated to get each entry in the keytab.
+* Added KeyBlock management APIs:
+  * [krb5_init_keyblock](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_init_keyblock.html)
+  * Due to differences between MIT and Heimdal this function reflects `krb5_keyblock_init` in Heimdal where the data is copied to the keyblock on creation
+* Added miscellaneous APIs:
+  * [krb5_string_to_enctype](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_string_to_enctype.html)
+  * [krb5_enctype_to_string](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_enctype_to_string.html)
+  * [krb5_enctype_to_name](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_enctype_to_name.html) - MIT only
+
+
 ## 0.2.0 - 2021-10-18
 
 * Added [krb5_cc_switch](https://web.mit.edu/kerberos/krb5-1.11/doc/appdev/refs/api/krb5_cc_switch.html)

--- a/setup.py
+++ b/setup.py
@@ -246,11 +246,14 @@ for e in [
     ("creds_opt_heimdal", "krb5_get_init_creds_opt_set_default_flags"),
     ("creds_opt_mit", "krb5_get_init_creds_opt_set_out_ccache"),
     "exceptions",
+    "keyblock",
     "kt",
     ("kt_mit", "krb5_kt_dup"),
     ("kt_heimdal", "krb5_kt_get_full_name"),
     "principal",
     ("principal_heimdal", "krb5_principal_get_realm"),
+    "string",
+    ("string_mit", "krb5_enctype_to_name"),
 ]:
     name = e
     canary = None
@@ -295,7 +298,7 @@ class sdist_krb5(sdist):
 
 setup(
     name="krb5",
-    version="0.2.0",
+    version="0.3.0",
     packages=find_packages(where="src"),
     package_data={
         "krb5": ["py.typed", "*.pyi"],

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -37,12 +37,19 @@ from krb5._creds_opt import (
     get_init_creds_opt_set_forwardable,
 )
 from krb5._exceptions import Krb5Error
+from krb5._keyblock import KeyBlock, init_keyblock
 from krb5._kt import (
     KeyTab,
+    KeyTabEntry,
+    kt_add_entry,
     kt_default,
     kt_default_name,
+    kt_get_entry,
     kt_get_name,
     kt_get_type,
+    kt_have_content,
+    kt_read_service_key,
+    kt_remove_entry,
     kt_resolve,
 )
 from krb5._principal import (
@@ -52,6 +59,7 @@ from krb5._principal import (
     parse_name_flags,
     unparse_name_flags,
 )
+from krb5._string import enctype_to_string, string_to_enctype
 
 __all__ = [
     "CCache",
@@ -59,7 +67,9 @@ __all__ = [
     "Creds",
     "GetInitCredsOpt",
     "InitCredsContext",
+    "KeyBlock",
     "KeyTab",
+    "KeyTabEntry",
     "Krb5Error",
     "Krb5Prompt",
     "Principal",
@@ -78,6 +88,7 @@ __all__ = [
     "cc_store_cred",
     "cc_support_switch",
     "cc_switch",
+    "enctype_to_string",
     "get_default_realm",
     "get_init_creds_keytab",
     "get_init_creds_opt_alloc",
@@ -90,13 +101,20 @@ __all__ = [
     "init_creds_init",
     "init_creds_set_keytab",
     "init_creds_set_password",
+    "init_keyblock",
+    "kt_add_entry",
     "kt_default",
     "kt_default_name",
+    "kt_get_entry",
     "kt_get_name",
     "kt_get_type",
+    "kt_have_content",
+    "kt_read_service_key",
+    "kt_remove_entry",
     "kt_resolve",
     "parse_name_flags",
     "set_default_realm",
+    "string_to_enctype",
     "unparse_name_flags",
 ]
 
@@ -163,3 +181,11 @@ except ImportError:
     pass
 else:
     __all__.extend(["principal_get_realm"])
+
+
+try:
+    from krb5._string_mit import enctype_to_name
+except ImportError:
+    pass
+else:
+    __all__.append("enctype_to_name")

--- a/src/krb5/_keyblock.pxd
+++ b/src/krb5/_keyblock.pxd
@@ -1,12 +1,11 @@
-# Copyright: (c) 2021 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
 from krb5._context cimport Context
 from krb5._krb5_types cimport *
 
 
-cdef class Principal:
+cdef class KeyBlock:
     cdef Context ctx
-    cdef krb5_principal raw
+    cdef krb5_keyblock *raw
     cdef int needs_free
-    cdef int _parse_flags

--- a/src/krb5/_keyblock.pyi
+++ b/src/krb5/_keyblock.pyi
@@ -1,0 +1,43 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import typing
+
+from krb5._context import Context
+
+class KeyBlock:
+    """Kerberos KeyBlock
+
+    This class represents the contents of a key.
+
+    Args:
+        context: Krb5 context.
+    """
+
+    def __len__(self) -> int: ...
+    @property
+    def data(self) -> bytes:
+        """The keyblock data."""
+    @property
+    def enctype(self) -> int:
+        """The keyblock encryption type."""
+
+def init_keyblock(
+    context: Context,
+    enctype: int,
+    key: typing.Optional[bytes],
+) -> KeyBlock:
+    """Initialize a Key Block.
+
+    Initalize a new keyblock and copy the key into the contents of that block.
+    The key can be None or an empty byte string to represent the contents are
+    not allocated.
+
+    Args:
+        context: Krb5 context.
+        enctype: The encryption type of the keyblock.
+        key: The data to place in the keyblock or None for an empty block.
+
+    Returns:
+        KeyBlock: The initialized keyblock.
+    """

--- a/src/krb5/_keyblock.pyx
+++ b/src/krb5/_keyblock.pyx
@@ -1,0 +1,156 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from libc.stdlib cimport free
+
+from krb5._exceptions import Krb5Error
+
+from krb5._context cimport Context
+from krb5._krb5_types cimport *
+
+
+cdef extern from "python_krb5.h":
+    # MIT and Heimdal have slightly different functions to init a keyblock
+    """
+    void pykrb5_keyblock_get(
+        krb5_keyblock *key,
+        krb5_enctype *enctype,
+        size_t *length,
+        char **data
+    )
+    {
+    #if defined(HEIMDAL_XFREE)
+        if (enctype != NULL) *enctype = key->keytype;
+        if (length != NULL) *length = key->keyvalue.length;
+        if (data != NULL) *data = key->keyvalue.data;
+    #else
+        if (enctype != NULL) *enctype = key->enctype;
+        if (length != NULL) *length = key->length;
+        if (data != NULL) *data = (char *)key->contents;
+    #endif
+    }
+
+    krb5_error_code krb5_init_keyblock_generic(
+        krb5_context context,
+        krb5_enctype enctype,
+        size_t length,
+        const char *data,
+        krb5_keyblock **out
+    )
+    {
+    #if defined(HEIMDAL_XFREE)
+        // While initialised here, krb5_free_keyblock will free this on deallocation
+        krb5_keyblock *keyblock = NULL;
+        keyblock = malloc(sizeof(krb5_keyblock));
+        if (keyblock == NULL)
+        {
+            return ENOMEM;
+        }
+
+        *out = keyblock;
+        return krb5_keyblock_init(context, enctype, data, length, keyblock);
+    #else
+        krb5_error_code err = 0;
+
+        err = krb5_init_keyblock(context, enctype, length, out);
+        if (err == 0 && length > 0)
+        {
+            memcpy((*out)->contents, data, length);
+        }
+
+        return err;
+    #endif
+    }
+    """
+
+    krb5_error_code krb5_init_keyblock_generic(
+        krb5_context context,
+        krb5_enctype enctype,
+        size_t length,
+        const char *data,
+        krb5_keyblock **out,
+    ) nogil
+
+    krb5_error_code krb5_free_keyblock(
+        krb5_context context,
+        krb5_keyblock *val,
+    ) nogil
+
+    void pykrb5_keyblock_get(
+        krb5_keyblock *key,
+        krb5_enctype *enctype,
+        size_t *length,
+        char **data,
+    ) nogil
+
+
+cdef class KeyBlock:
+    # cdef Context ctx
+    # cdef krb5_keyblock *raw
+    # cdef int needs_free
+
+    def __cinit__(KeyBlock self, Context context, needs_free=1):
+        self.ctx = context
+        self.raw = NULL
+        self.needs_free = needs_free
+
+    def __dealloc__(KeyBlock self):
+        if self.raw != NULL and self.needs_free:
+            krb5_free_keyblock(self.ctx.raw, self.raw)
+            self.raw = NULL
+
+    def __len__(KeyBlock self) -> int:
+        cdef size_t length
+        pykrb5_keyblock_get(self.raw, NULL, &length, NULL)
+
+        return length
+
+    def __repr__(KeyBlock self) -> str:
+        kwargs = [f"{k}={v}" for k, v in {
+            'enctype': self.enctype,
+            'length': len(self),
+        }.items()]
+
+        return f"KeyBlock({', '.join(kwargs)})"
+
+    def __str__(KeyBlock self) -> str:
+        return f"KeyBlock {self.enctype}"
+
+    @property
+    def data(KeyBlock self) -> bytes:
+        cdef size_t length
+        cdef char *data
+        pykrb5_keyblock_get(self.raw, NULL, &length, &data)
+
+        if length == 0:
+            return b""
+        else:
+            return data[:length]
+
+    @property
+    def enctype(KeyBlock self) -> int:
+        cdef krb5_enctype enctype
+        pykrb5_keyblock_get(self.raw, &enctype, NULL, NULL)
+
+        return enctype
+
+
+def init_keyblock(
+    Context context not None,
+    krb5_enctype enctype,
+    const unsigned char[:] key,
+) -> KeyBlock:
+    kb = KeyBlock(context)
+    cdef krb5_error_code err = 0
+    cdef size_t length = 0
+
+    cdef const char *key_ptr = NULL
+    if key is not None and len(key):
+        length = len(key)
+        key_ptr = <const char*>&key[0]
+
+    err = krb5_init_keyblock_generic(context.raw, enctype, length, key_ptr, &kb.raw)
+    if err:
+        raise Krb5Error(context, err)
+
+    return kb

--- a/src/krb5/_krb5_types.pxd
+++ b/src/krb5/_krb5_types.pxd
@@ -1,19 +1,21 @@
 # Copyright: (c) 2021 Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
-from libc.stdint cimport int32_t, uint8_t
+from libc.stdint cimport int32_t, uint8_t, uint32_t
 
 
 cdef extern from "python_krb5.h":
     ctypedef int32_t krb5_int32
     ctypedef krb5_int32 krb5_error_code
     ctypedef krb5_int32 krb5_deltat
-    ctypedef krb5_error_code krb5_magic
     ctypedef krb5_int32 krb5_enctype
     ctypedef uint8_t krb5_octet
     ctypedef krb5_int32 krb5_timestamp
     ctypedef unsigned int krb5_boolean
-    ctypedef krb5_int32 krb5_flags
+    ctypedef unsigned int krb5_kvno
+
+    ctypedef void *krb5_pointer;
+    ctypedef krb5_pointer krb5_kt_cursor;
 
     cdef struct _krb5_context:
         pass
@@ -37,49 +39,23 @@ cdef extern from "python_krb5.h":
     ctypedef _krb5_init_creds_context *krb5_init_creds_context
 
     cdef struct _krb5_keyblock:
-        krb5_magic magic
-        krb5_enctype enctype
-        unsigned int length
-        krb5_octet *contexts
+        pass
     ctypedef _krb5_keyblock krb5_keyblock
 
-    cdef struct _krb5_ticket_times:
-        krb5_timestamp authtime
-        krb5_timestamp starttime
-        krb5_timestamp endtime
-        krb5_timestamp renew_till
-    ctypedef _krb5_ticket_times krb5_ticket_times
-
-    cdef struct _krb5_address:
-        pass
-    ctypedef _krb5_address krb5_address
-
     cdef struct _krb5_data:
-        krb5_magic magic
-        unsigned int length
-        char *data
-    ctypedef _krb5_data krb5_data
-
-    cdef struct _krb5_authdata:
         pass
-    ctypedef _krb5_authdata krb5_authdata
+    ctypedef _krb5_data krb5_data
 
     cdef struct _krb5_kt:
         pass
     ctypedef _krb5_kt *krb5_keytab
 
+    cdef struct krb5_keytab_entry_st:
+        pass
+    ctypedef krb5_keytab_entry_st krb5_keytab_entry
+
     cdef struct _krb5_creds:
-        krb5_magic magic
-        krb5_principal client
-        krb5_principal server
-        krb5_keyblock keyblock
-        krb5_ticket_times times
-        krb5_boolean is_skey
-        krb5_flags ticket_flags
-        krb5_address **addresses
-        krb5_data ticket
-        krb5_data second_ticket
-        krb5_authdata **authdata
+        pass
     ctypedef _krb5_creds krb5_creds
 
     cdef struct _krb5_prompt:

--- a/src/krb5/_kt.pxd
+++ b/src/krb5/_kt.pxd
@@ -8,3 +8,9 @@ from krb5._krb5_types cimport *
 cdef class KeyTab:
     cdef Context ctx
     cdef krb5_keytab raw
+
+
+cdef class KeyTabEntry:
+    cdef Context ctx
+    cdef krb5_keytab_entry raw
+    cdef int needs_free

--- a/src/krb5/_principal.pyx
+++ b/src/krb5/_principal.pyx
@@ -85,15 +85,17 @@ cdef class Principal:
     """
     # cdef Context ctx
     # cdef krb5_principal raw
+    # cdef int needs_free
     # cdef int _parse_flags
 
-    def __cinit__(Principal self, Context context, flags):
+    def __cinit__(Principal self, Context context, flags, int needs_free=1):
         self.ctx = context
         self.raw = NULL
+        self.needs_free = needs_free
         self._parse_flags = flags
 
     def __dealloc__(Principal self):
-        if self.raw:
+        if self.raw and self.needs_free:
             krb5_free_principal(self.ctx.raw, self.raw)
             self.raw = NULL
 

--- a/src/krb5/_string.pyi
+++ b/src/krb5/_string.pyi
@@ -1,0 +1,44 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from krb5._context import Context
+
+def enctype_to_string(
+    context: Context,
+    enctype: int,
+) -> str:
+    """Convert an encryption type to a string.
+
+    Converts the encryption type identifier to the string name representation.
+
+    Note:
+        This API is marked as public but should not be called directly in MIT.
+
+    Note:
+        The Heimdal and MIT implementation return quite different values. It is
+        recommended to use :meth:`enctype_to_name` if available on MIT to get
+        a common value back.
+
+    Args:
+        context: Krb5 context.
+        enctype: The encryption type identifier to convert.
+
+    Returns:
+        str: The encryption type name.
+    """
+
+def string_to_enctype(
+    context: Context,
+    string: str,
+) -> int:
+    """Convert string to encryption type.
+
+    Converts a string to an encryption type integer.
+
+    Args:
+        context: Krb5 context.
+        string: The string to convert from.
+
+    Returns:
+        int: The encryption type.
+    """

--- a/src/krb5/_string.pyx
+++ b/src/krb5/_string.pyx
@@ -1,0 +1,94 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from libc.stdlib cimport free
+
+from krb5._exceptions import Krb5Error
+
+from krb5._context cimport Context
+from krb5._krb5_types cimport *
+
+
+cdef extern from "python_krb5.h":
+    # Heimdal and MIT differ in their implementations
+    """
+    krb5_error_code krb5_enctype_to_string_generic(
+        krb5_context context,
+        krb5_enctype enctype,
+        char **buffer
+    )
+    {
+    // Heimdal takes in a context and sets an output pointer
+    #if defined(HEIMDAL_XFREE)
+        return krb5_enctype_to_string(context, enctype, buffer);
+    #else
+        char *tmp = malloc(100);
+        if (tmp == NULL)
+        {
+            return ENOMEM;
+        }
+        *buffer = tmp;
+
+        return krb5_enctype_to_string(enctype, tmp, 100);
+    #endif
+    }
+
+    krb5_error_code krb5_string_to_enctype_generic(
+        krb5_context context,
+        char *string,
+        krb5_enctype *enctypep
+    )
+    {
+    // MIT does not have a context overload
+    #if defined(HEIMDAL_XFREE)
+        return krb5_string_to_enctype(context, string, enctypep);
+    #else
+        return krb5_string_to_enctype(string, enctypep);
+    #endif
+    }
+    """
+
+    krb5_error_code krb5_enctype_to_string_generic(
+        krb5_context context,
+        krb5_enctype enctype,
+        char **buffer,
+    ) nogil
+
+    krb5_error_code krb5_string_to_enctype_generic(
+        krb5_context context,
+        char *string,
+        krb5_enctype *enctypep,
+    ) nogil
+
+
+def enctype_to_string(
+    Context context not None,
+    krb5_enctype enctype,
+) -> str:
+    cdef krb5_error_code err = 0
+    cdef char *buffer = NULL
+
+    err = krb5_enctype_to_string_generic(context.raw, enctype, &buffer)
+    if err:
+        raise Krb5Error(context, err)
+
+    try:
+        return buffer.decode("utf-8")
+    finally:
+        free(buffer)
+
+
+def string_to_enctype(
+    Context context not None,
+    str string,
+) -> int:
+    cdef krb5_enctype enctype = 0
+    cdef krb5_error_code err = 0
+    b_string = string.encode("utf-8")
+    cdef char *string_ptr = b_string
+
+    err = krb5_string_to_enctype_generic(context.raw, string_ptr, &enctype)
+    if err:
+        raise Krb5Error(context, err)
+
+    return enctype

--- a/src/krb5/_string_mit.pyi
+++ b/src/krb5/_string_mit.pyi
@@ -1,0 +1,26 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+def enctype_to_name(
+    enctype: int,
+    shortest: bool = False,
+) -> str:
+    """Convert an encryption type to a name or alias.
+
+    Converts the encryption type identifier to either the full canonical name
+    or the types shortest alias.
+
+    Note:
+        This API is marked as public but should not be called directly in MIT.
+
+    Args:
+        enctype: The encryption type identifier to convert.
+        shortest: Return the shortest alias if `True` otherwise return the full
+            canonical name.
+
+    Returns:
+        str: The encryption type name.
+
+    Raises:
+        ValueError: If the encryption type is invalid
+    """

--- a/src/krb5/_string_mit.pyx
+++ b/src/krb5/_string_mit.pyx
@@ -1,0 +1,36 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from libc.stdlib cimport free, malloc
+
+from krb5._exceptions import Krb5Error
+
+from krb5._krb5_types cimport *
+
+
+cdef extern from "python_krb5.h":
+    krb5_error_code krb5_enctype_to_name(
+        krb5_enctype enctype,
+        krb5_boolean shortest,
+        char *buffer,
+        size_t buflen,
+    ) nogil
+
+
+def enctype_to_name(
+    krb5_enctype enctype,
+    krb5_boolean shortest = False,
+) -> str:
+    cdef krb5_error_code err = 0
+    cdef void *buffer = malloc(100)
+    if buffer == NULL:
+        raise MemoryError()
+
+    err = krb5_enctype_to_name(enctype, shortest, <char *>buffer, 100)
+    if err:
+        raise ValueError("Invalid encryption type")
+
+    try:
+        return (<char *>buffer).decode("utf-8")
+    finally:
+        free(buffer)

--- a/tests/test_ccache.py
+++ b/tests/test_ccache.py
@@ -219,7 +219,6 @@ def test_cc_switch(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
     user_ccache = krb5.cc_resolve(ctx, b"DIR::" + bytes(tmp_path / "tkt-user"))
     krb5.cc_initialize(ctx, user_ccache, user_princ)
 
-    print(user_ccache.name)
     krb5.cc_switch(ctx, user_ccache)
 
     actual = krb5.cc_resolve(ctx, b"DIR:" + bytes(tmp_path))

--- a/tests/test_keyblock.py
+++ b/tests/test_keyblock.py
@@ -1,0 +1,28 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import pytest
+
+import krb5
+
+
+def test_init_keyblock_empty() -> None:
+    ctx = krb5.init_context()
+    kb = krb5.init_keyblock(ctx, 0, None)
+
+    assert len(kb) == 0
+    assert kb.enctype == 0
+    assert kb.data == b""
+    assert str(kb) == "KeyBlock 0"
+    assert repr(kb) == "KeyBlock(enctype=0, length=0)"
+
+
+def test_init_keyblock_data() -> None:
+    ctx = krb5.init_context()
+    kb = krb5.init_keyblock(ctx, 17, b"\xff" * 16)
+
+    assert len(kb) == 16
+    assert kb.enctype == 17
+    assert kb.data == b"\xff" * 16
+    assert str(kb) == "KeyBlock 17"
+    assert repr(kb) == "KeyBlock(enctype=17, length=16)"

--- a/tests/test_kt.py
+++ b/tests/test_kt.py
@@ -55,6 +55,199 @@ def test_kt_get_type(tmp_path: pathlib.Path) -> None:
     assert krb5.kt_get_type(ctx, kt) == b"FILE"
 
 
+def test_kt_have_content(tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+
+    assert krb5.kt_have_content(ctx, kt) is False
+
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    key_block = krb5.init_keyblock(ctx, 17, b"\x00" * 16)
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, key_block)
+
+    assert krb5.kt_have_content(ctx, kt)
+
+    entry = list(kt)[0]
+    krb5.kt_remove_entry(ctx, kt, entry)
+
+    assert krb5.kt_have_content(ctx, kt) is False
+
+
+def test_kt_enumerate(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+
+    msg_pattern = "Key table file '.*' not found" if realm.provider == "mit" else "No such file or directory"
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        list(kt)
+
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    key_block = krb5.init_keyblock(ctx, 17, b"\x00" * 16)
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, key_block)
+
+    entries = list(kt)
+    assert len(entries) == 1
+    assert entries[0].principal.name == b"user@DOMAIN.COM"
+    assert entries[0].kvno == 1
+    assert isinstance(entries[0].timestamp, int)
+
+    krb5.kt_remove_entry(ctx, kt, entries[0])
+
+    entries = list(kt)
+    assert entries == []
+
+
+def test_kt_get_entry_empty(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+
+    msg_pattern = "Key table file '.*' not found" if realm.provider == "mit" else "No such file or directory"
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        krb5.kt_get_entry(ctx, kt, princ)
+
+
+def test_kt_get_entry(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    key_block = krb5.init_keyblock(ctx, 17, b"\xff" * 16)
+    assert key_block.enctype == 17
+    assert key_block.data == b"\xff" * 16
+
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, key_block)
+
+    entry = krb5.kt_get_entry(ctx, kt, princ)
+    assert entry.principal.name == princ.name
+    assert entry.kvno == 1
+    assert entry.key.enctype == 17
+    assert entry.key.data == key_block.data
+
+    krb5.kt_remove_entry(ctx, kt, entry)
+    assert list(kt) == []
+
+    msg_pattern = "No key table entry found" if realm.provider == "mit" else "Failed to find .* in keytab .*"
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        krb5.kt_get_entry(ctx, kt, princ)
+
+
+def test_kt_get_entry_multiple_kvno(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    key_block = krb5.init_keyblock(ctx, 17, b"\x00" * 16)
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, key_block)
+    krb5.kt_add_entry(ctx, kt, princ, 2, 0, key_block)
+
+    entry = krb5.kt_get_entry(ctx, kt, princ)
+    assert entry.principal.name == princ.name
+    assert entry.kvno == 2
+
+    entry = krb5.kt_get_entry(ctx, kt, princ, kvno=1)
+    assert entry.principal.name == princ.name
+    assert entry.kvno == 1
+
+    msg_pattern = (
+        "Key version number for principal in key table is incorrect"
+        if realm.provider == "mit"
+        else "Failed to find .* in keytab .*"
+    )
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        krb5.kt_get_entry(ctx, kt, princ, kvno=3)
+
+
+def test_kt_get_entry_multiple_enctype(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, krb5.init_keyblock(ctx, 17, b"\x00" * 16))
+    krb5.kt_add_entry(ctx, kt, princ, 2, 0, krb5.init_keyblock(ctx, 18, b"\x00" * 32))
+
+    entry = krb5.kt_get_entry(ctx, kt, princ)
+    assert entry.principal.name == princ.name
+    assert entry.kvno == 2
+    assert entry.key.enctype == 18
+
+    entry = krb5.kt_get_entry(ctx, kt, princ, enctype=17)
+    assert entry.principal.name == princ.name
+    assert entry.kvno == 1
+    assert entry.key.enctype == 17
+
+    msg_pattern = "No key table entry found" if realm.provider == "mit" else "Failed to find .* in keytab .*"
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        krb5.kt_get_entry(ctx, kt, princ, enctype=16)
+
+
+def test_kt_read_service_key_empty(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+
+    msg_pattern = "Key table file '.*' not found" if realm.provider == "mit" else "No such file or directory"
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        krb5.kt_read_service_key(ctx, kt.name, princ)
+
+
+def test_kt_read_service_key(tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    key_block = krb5.init_keyblock(ctx, 17, b"\xff" * 16)
+    assert key_block.enctype == 17
+    assert key_block.data == b"\xff" * 16
+
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, key_block)
+
+    key = krb5.kt_read_service_key(ctx, kt.name, princ)
+    assert key.enctype == 17
+    assert key.data == b"\xff" * 16
+
+
+def test_kt_read_service_key_multiple_kvno(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, krb5.init_keyblock(ctx, 17, b"\x00" * 16))
+    krb5.kt_add_entry(ctx, kt, princ, 2, 0, krb5.init_keyblock(ctx, 18, b"\x11" * 32))
+
+    key = krb5.kt_read_service_key(ctx, kt.name, princ)
+    assert key.enctype == 18
+    assert key.data == b"\x11" * 32
+
+    key = krb5.kt_read_service_key(ctx, kt.name, princ, kvno=1)
+    assert key.enctype == 17
+    assert key.data == b"\x00" * 16
+
+    msg_pattern = (
+        "Key version number for principal in key table is incorrect"
+        if realm.provider == "mit"
+        else "Failed to find .* in keytab .*"
+    )
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        krb5.kt_read_service_key(ctx, kt.name, princ, kvno=3)
+
+
+def test_kt_read_service_key_multiple_enctype(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
+    ctx = krb5.init_context()
+    kt = krb5.kt_resolve(ctx, f"FILE:{tmp_path / 'keytab'}".encode())
+    princ = krb5.parse_name_flags(ctx, b"user@DOMAIN.COM")
+    krb5.kt_add_entry(ctx, kt, princ, 1, 0, krb5.init_keyblock(ctx, 17, b"\x00" * 16))
+    krb5.kt_add_entry(ctx, kt, princ, 2, 0, krb5.init_keyblock(ctx, 18, b"\x11" * 32))
+
+    key = krb5.kt_read_service_key(ctx, kt.name, princ)
+    assert key.enctype == 18
+    assert key.data == b"\x11" * 32
+
+    key = krb5.kt_read_service_key(ctx, kt.name, princ, enctype=17)
+    assert key.enctype == 17
+    assert key.data == b"\x00" * 16
+
+    msg_pattern = "No key table entry found" if realm.provider == "mit" else "Failed to find .* in keytab .*"
+    with pytest.raises(krb5.Krb5Error, match=msg_pattern):
+        krb5.kt_read_service_key(ctx, kt.name, princ, enctype=16)
+
+
 def test_kt_resolve(tmp_path: pathlib.Path) -> None:
     ctx = krb5.init_context()
 

--- a/tests/test_string.py
+++ b/tests/test_string.py
@@ -1,0 +1,47 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import k5test
+import pytest
+
+import krb5
+
+
+def test_enctype_to_string(realm: k5test.K5Realm) -> None:
+    expected = "AES-256 CTS mode with 96-bit SHA-1 HMAC" if realm.provider == "mit" else "aes256-cts-hmac-sha1-96"
+    ctx = krb5.init_context()
+    name = krb5.enctype_to_string(ctx, 18)
+    assert name == expected
+
+
+def test_enctype_to_string_invalid(realm: k5test.K5Realm) -> None:
+    ctx = krb5.init_context()
+
+    expected_msg = "Invalid argument" if realm.provider == "mit" else "encryption type \\d+ not supported"
+    with pytest.raises(krb5.Krb5Error, match=expected_msg):
+        krb5.enctype_to_string(ctx, 1024)
+
+
+def test_string_to_enctype() -> None:
+    ctx = krb5.init_context()
+    enctype = krb5.string_to_enctype(ctx, "aes256-cts-hmac-sha1-96")
+    assert enctype == 18
+
+
+def test_string_to_enctype_invalid(realm: k5test.K5Realm) -> None:
+    ctx = krb5.init_context()
+    expected_msg = "Invalid argument" if realm.provider == "mit" else "encryption type invalid not supported"
+    with pytest.raises(krb5.Krb5Error, match=expected_msg):
+        krb5.string_to_enctype(ctx, "invalid")
+
+
+@pytest.mark.requires_api("enctype_to_name")
+def test_string_to_name() -> None:
+    name = krb5.enctype_to_name(18)
+    assert name == "aes256-cts-hmac-sha1-96"
+
+
+@pytest.mark.requires_api("enctype_to_name")
+def test_string_to_name_shortest() -> None:
+    name = krb5.enctype_to_name(18, shortest=True)
+    assert name == "aes256-cts"


### PR DESCRIPTION
Adds the basic set of functions that are used to manage a keytab. These
functions allow the caller to enumerate a keytab as well as add/remote
any entries in a keytab. There are also some limited calls to inspect
the values of each entry.

Finally there are some APIs for creating a new keyblock that is required
when adding to a keytab. These APIs are fairly rudimentary. More
advanced APIs need to be added at a later date to make this more inline
with what the `ktutil` command can do.

Fixes https://github.com/jborean93/pykrb5/issues/8