### PR TITLE
Migrate to using PEP 517

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,8 @@ on:
     types:
     - published
 
-  schedule:
-  - cron: 0 9 * * *
-
 jobs:
-  build:
+  build_sdist:
     name: build sdist
     runs-on: ubuntu-latest
     steps:
@@ -34,20 +31,12 @@ jobs:
       with:
         python-version: 3.9
 
-    - name: install build pre-requisites
-      run: pip install setuptools Cython
-
-    # FUTURE: This shouldn't be needed to generate the sdist
-    - name: install Linux pre-reqs
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y \
-          libkrb5-dev
-
     - name: build sdist
-      run: python setup.py sdist
+      run: |
+        python -m pip install build
+        python -m build --sdist
       env:
-        KRB5_SKIP_MODULE_CHECK: true
+        KRB5_SKIP_EXTENSIONS: true
 
     - uses: actions/upload-artifact@v2
       with:
@@ -57,16 +46,15 @@ jobs:
   build_wheels:
     name: build wheels
     needs:
-    - build
+    - build_sdist
 
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os:
-        - macOS-10.15
+        - macOS-12
         version:
-        - cp36-macosx_x86_64
         - cp37-macosx_x86_64
         - cp38-macosx_x86_64
         - cp38-macosx_arm64
@@ -104,7 +92,7 @@ jobs:
   test:
     name: test
     needs:
-    - build
+    - build_sdist
     - build_wheels
 
     runs-on: ${{ matrix.os }}
@@ -113,9 +101,8 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macOS-10.15
+        - macOS-12
         python-version:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9
@@ -125,7 +112,7 @@ jobs:
         - heimdal
 
         exclude:
-        - os: macOS-10.15
+        - os: macOS-12
           provider: mit
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 21.6b0
+  rev: 22.6.0
   hooks:
   - id: black
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.9.1
+  rev: 5.10.1
   hooks:
   - id: isort
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.910
+  rev: v0.971
   hooks:
   - id: mypy
     exclude: setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.0 - TBD
+
+* Require Python 3.7 or newer (dropped 3.6)
+* Created PEP 517 compliant package
+* Moved all setuptools configuration, except extension information, to `pyproject.toml`
+* Will no longer include the cythonised `.c` files in the sdist making Cython a build requirement
+  * With PEP 517 this requirement will be automatically satisfied making this a non-breaking change for people using PEP 517 features
+
 ## 0.3.0 - 2022-02-16
 
 * Added CCache APIs:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-include __dont_use_cython__.txt
 include CHANGELOG.md
 include LICENSE
 exclude .coverage
@@ -8,6 +7,7 @@ recursive-include build_helpers *
 include src/krb5/*.h
 include src/krb5/*.pyx
 include src/krb5/*.pxd
+exclude src/krb5/*.c
 recursive-include stubs *
 recursive-include tests *
 recursive-exclude tests *.pyc

--- a/build_helpers/lib.sh
+++ b/build_helpers/lib.sh
@@ -47,16 +47,15 @@ lib::setup::python_requirements() {
         echo "::group::Installing Python Requirements"
     fi
 
-    python -m pip install --upgrade pip setuptools wheel
-
     echo "Installing krb5"
-    python -m pip install krb5 \
-        --no-index \
+
+    # Getting the version is important so that pip prioritises our local dist
+    python -m pip install build
+    KRB5_VERSION="$( python -c "import build.util; print(build.util.project_wheel_metadata('.').get('Version'))" )"
+
+    python -m pip install krb5=="${KRB5_VERSION}" \
         --find-links "file:///${PWD}/dist" \
-        --no-build-isolation \
-        --no-dependencies \
         --verbose
-    python -m pip install krb5
 
     echo "Installing dev dependencies"
     python -m pip install -r requirements-dev.txt

--- a/build_helpers/run-container.sh
+++ b/build_helpers/run-container.sh
@@ -16,12 +16,12 @@ source ./build_helpers/lib.sh
 lib::setup::system_requirements
 
 apt-get -y install \
-    cython3 \
     python3 \
-    python3-{dev,pip,setuptools,virtualenv,wheel}
+    python3-{dev,pip,venv}
 ln -s /usr/bin/python3 /usr/bin/python
 
-python setup.py bdist_wheel
+python -m pip install build
+python -m build
 lib::setup::python_requirements
 
 # Ensure we don't pollute the local dir + mypy doesn't like this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,45 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel"]
+requires = [
+    "Cython >= 0.29.29, < 3.0.0",  # 0.29.29 includes fixes for Python 3.11
+    "setuptools >= 61.0.0",  # Support for setuptools config in pyproject.toml
+]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "krb5"
+version = "0.4.0"
+description = "Kerberos API bindings for Python"
+readme = "README.md"
+requires-python = ">=3.7"
+license = {file = "LICENSE"}
+authors = [
+    { name = "Jordan Borean", email = "jborean93@gmail.com" }
+]
+keywords = ["krb5", "kerberos"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10"
+]
+
+[project.urls]
+homepage = "https://github.com/jborean93/pykrb5"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+krb5 = ["py.typed", "*.pyi"]
+
+[tool.setuptools.exclude-package-data]
+krb5 = ["*.pxd", "*.pyx"]
 
 [tool.black]
 line-length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,7 @@
-Cython
-black
-isort
+black==22.6.0
+isort==5.10.1
 k5test>=0.10.0
-mypy
+mypy==0.971
 pre-commit
 pytest
 tox
-wheel

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ https://github.com/pythongssapi/python-gssapi/blob/main/setup.py
 
 import ctypes
 import ctypes.util
-import glob
 import os
 import os.path
 import platform
@@ -22,25 +21,12 @@ import subprocess
 import sys
 import typing
 
-from setuptools import Extension, find_packages, setup
-from setuptools.command.sdist import sdist
+from Cython.Build import cythonize
+from setuptools import Extension, setup
 
-SKIP_CYTHON_FILE = "__dont_use_cython__.txt"
+SKIP_EXTENSIONS = os.environ.get("KRB5_SKIP_EXTENSIONS", "false").lower() == "true"
 SKIP_MODULE_CHECK = os.environ.get("KRB5_SKIP_MODULE_CHECK", "false").lower() == "true"
 CYTHON_LINETRACE = os.environ.get("KRB5_CYTHON_TRACING", "false").lower() == "true"
-
-if os.path.exists(SKIP_CYTHON_FILE):
-    print("In distributed package, building from C files...")
-    SOURCE_EXT = "c"
-else:
-    try:
-        from Cython.Build import cythonize
-
-        print("Building from Cython files...")
-        SOURCE_EXT = "pyx"
-    except ImportError:
-        print("Cython not found, building from C files...")
-        SOURCE_EXT = "c"
 
 
 def run_command(*args: str) -> str:
@@ -54,7 +40,7 @@ def make_extension(
     canary: typing.Optional[str] = None,
     **kwargs: typing.Any,
 ) -> Extension:
-    source = os.path.join("src", name.replace(".", os.sep)) + f".{SOURCE_EXT}"
+    source = os.path.join("src", name.replace(".", os.sep)) + ".pyx"
 
     if not SKIP_MODULE_CHECK and canary and not hasattr(module, canary):
         print(f"Skipping {source} as it is not supported by the selected Kerberos implementation.")
@@ -167,174 +153,120 @@ def get_krb5_lib_path(
     return os.path.join(krb5_path, krb5_lib)
 
 
-with open(os.path.join(os.path.dirname(__file__), "README.md"), mode="rb") as fd:
-    long_description = fd.read().decode("utf-8")
-
-kc = get_krb5_config()
-print(f"Using krb5-config at '{kc}'")
-
-macos_native = False
-if sys.platform == "darwin":
-    mac_ver = [int(v) for v in platform.mac_ver()[0].split(".")]
-    macos_native = mac_ver >= [10, 7, 0]
-
-compile_args, raw_link_args = [
-    shlex.split(os.environ[e], posix=True) if e in os.environ else None
-    for e in ["KRB5_COMPILER_ARGS", "KRB5_LINKER_ARGS"]
-]
-if compile_args is None:
-    if macos_native:
-        compile_args = []
-
-    else:
-        compile_args = shlex.split(run_command(f"{kc} --cflags krb5"))
-
-    compile_args.append("-Werror")
-
-    # Python 3.8 on macOS errors on these deprecation warnings. We ignore them as things are fixed on 3.9 but the
-    # code still needs to compile on 3.8.
-    if sys.platform == "darwin" and sys.version_info[:2] == (3, 8):
-        compile_args.append("-Wno-deprecated")
-
-    if CYTHON_LINETRACE:
-        compile_args.append("-DCYTHON_TRACE_NOGIL=1")
-
-if raw_link_args is None:
-    if macos_native:
-        raw_link_args = ["-framework", "Heimdal", "-F", "/System/Library/PrivateFrameworks"]
-
-    else:
-        raw_link_args = shlex.split(run_command(f"{kc} --libs krb5"))
-
-library_dirs, include_dirs, libraries, link_args = [], [], [], []
-for arg in raw_link_args:
-    if arg.startswith("-L"):
-        library_dirs.append(arg[2:])
-    elif arg.startswith("-l"):
-        libraries.append(arg[2:])
-    elif arg.startswith("-I"):
-        include_dirs.append(arg[2:])
-    else:
-        link_args.append(arg)
-
-if macos_native:
-    # Because this is doing a naughty thing and linking against a private framework there are no krb5.h header files
-    # available. A hack is to just compile Heimdal itself and include that during compilation.
-    heimdal_dir = os.environ.get("KRB5_MACOS_HEIMDAL_DIR", "")
-    if not heimdal_dir:
-        heimdal_dir = os.path.join(os.path.dirname(__file__), "build_helpers", "heimdal")
-
-    include_dirs.append(os.path.join(os.path.abspath(heimdal_dir), "include"))
-
-
-krb5_path = get_krb5_lib_path(libraries, library_dirs, link_args, macos_native)
-print(f"Using {krb5_path} as Kerberos module for platform checks")
-krb5 = ctypes.CDLL(krb5_path)
-
-if hasattr(krb5, "krb5_xfree"):
-    compile_args.append("-DHEIMDAL_XFREE")
-
-
 raw_extensions = []
-for e in [
-    "ccache",
-    ("ccache_mit", "krb5_cc_dup"),
-    ("ccache_match", "krb5_cc_cache_match"),
-    ("ccache_support_switch", "krb5_cc_support_switch"),
-    "cccol",
-    "context",
-    ("context_mit", "krb5_init_secure_context"),
-    "creds",
-    "creds_opt",
-    ("creds_opt_heimdal", "krb5_get_init_creds_opt_set_default_flags"),
-    ("creds_opt_mit", "krb5_get_init_creds_opt_set_out_ccache"),
-    ("creds_opt_set_in_ccache", "krb5_get_init_creds_opt_set_in_ccache"),
-    ("creds_opt_set_pac_request", "krb5_get_init_creds_opt_set_pac_request"),
-    "exceptions",
-    "keyblock",
-    "kt",
-    ("kt_mit", "krb5_kt_dup"),
-    ("kt_heimdal", "krb5_kt_get_full_name"),
-    ("kt_have_content", "krb5_kt_have_content"),
-    "principal",
-    ("principal_heimdal", "krb5_principal_get_realm"),
-    "string",
-    ("string_mit", "krb5_enctype_to_name"),
-]:
-    name = e
-    canary = None
-    if isinstance(e, tuple):
-        name = e[0]
-        if len(e) > 1:
-            canary = e[1]
+if not SKIP_EXTENSIONS:
+    kc = get_krb5_config()
+    print(f"Using krb5-config at '{kc}'")
 
-    ext = make_extension(
-        f"krb5._{name}",
-        module=krb5,
-        canary=canary,
-        extra_link_args=link_args,
-        extra_compile_args=compile_args,
-        include_dirs=include_dirs,
-        library_dirs=library_dirs,
-        libraries=libraries,
-    )
-    if ext:
-        raw_extensions.append(ext)
+    macos_native = False
+    if sys.platform == "darwin":
+        mac_ver = [int(v) for v in platform.mac_ver()[0].split(".")]
+        macos_native = mac_ver >= [10, 7, 0]
 
-if SOURCE_EXT == "c":
-    extensions = raw_extensions
-else:
-    extensions = cythonize(
+    compile_args, raw_link_args = [
+        shlex.split(os.environ[e], posix=True) if e in os.environ else None
+        for e in ["KRB5_COMPILER_ARGS", "KRB5_LINKER_ARGS"]
+    ]
+    if compile_args is None:
+        if macos_native:
+            compile_args = []
+
+        else:
+            compile_args = shlex.split(run_command(f"{kc} --cflags krb5"))
+
+        compile_args.append("-Werror")
+
+        # Python 3.8 on macOS errors on these deprecation warnings. We ignore them as things are fixed on 3.9 but the
+        # code still needs to compile on 3.8.
+        if sys.platform == "darwin" and sys.version_info[:2] == (3, 8):
+            compile_args.append("-Wno-deprecated")
+
+        if CYTHON_LINETRACE:
+            compile_args.append("-DCYTHON_TRACE_NOGIL=1")
+
+    if raw_link_args is None:
+        if macos_native:
+            raw_link_args = ["-framework", "Heimdal", "-F", "/System/Library/PrivateFrameworks"]
+
+        else:
+            raw_link_args = shlex.split(run_command(f"{kc} --libs krb5"))
+
+    library_dirs, include_dirs, libraries, link_args = [], [], [], []
+    for arg in raw_link_args:
+        if arg.startswith("-L"):
+            library_dirs.append(arg[2:])
+        elif arg.startswith("-l"):
+            libraries.append(arg[2:])
+        elif arg.startswith("-I"):
+            include_dirs.append(arg[2:])
+        else:
+            link_args.append(arg)
+
+    if macos_native:
+        # Because this is doing a naughty thing and linking against a private framework there are no krb5.h header files
+        # available. A hack is to just compile Heimdal itself and include that during compilation.
+        heimdal_dir = os.environ.get("KRB5_MACOS_HEIMDAL_DIR", "")
+        if not heimdal_dir:
+            heimdal_dir = os.path.join(os.path.dirname(__file__), "build_helpers", "heimdal")
+
+        include_dirs.append(os.path.join(os.path.abspath(heimdal_dir), "include"))
+
+    krb5_path = get_krb5_lib_path(libraries, library_dirs, link_args, macos_native)
+    print(f"Using {krb5_path} as Kerberos module for platform checks")
+    krb5 = ctypes.CDLL(krb5_path)
+
+    if hasattr(krb5, "krb5_xfree"):
+        compile_args.append("-DHEIMDAL_XFREE")
+
+    for e in [
+        "ccache",
+        ("ccache_mit", "krb5_cc_dup"),
+        ("ccache_match", "krb5_cc_cache_match"),
+        ("ccache_support_switch", "krb5_cc_support_switch"),
+        "cccol",
+        "context",
+        ("context_mit", "krb5_init_secure_context"),
+        "creds",
+        "creds_opt",
+        ("creds_opt_heimdal", "krb5_get_init_creds_opt_set_default_flags"),
+        ("creds_opt_mit", "krb5_get_init_creds_opt_set_out_ccache"),
+        ("creds_opt_set_in_ccache", "krb5_get_init_creds_opt_set_in_ccache"),
+        ("creds_opt_set_pac_request", "krb5_get_init_creds_opt_set_pac_request"),
+        "exceptions",
+        "keyblock",
+        "kt",
+        ("kt_mit", "krb5_kt_dup"),
+        ("kt_heimdal", "krb5_kt_get_full_name"),
+        ("kt_have_content", "krb5_kt_have_content"),
+        "principal",
+        ("principal_heimdal", "krb5_principal_get_realm"),
+        "string",
+        ("string_mit", "krb5_enctype_to_name"),
+    ]:
+        name = e
+        canary = None
+        if isinstance(e, tuple):
+            name = e[0]
+            if len(e) > 1:
+                canary = e[1]
+
+        ext = make_extension(
+            f"krb5._{name}",
+            module=krb5,
+            canary=canary,
+            extra_link_args=link_args,
+            extra_compile_args=compile_args,
+            include_dirs=include_dirs,
+            library_dirs=library_dirs,
+            libraries=libraries,
+        )
+        if ext:
+            raw_extensions.append(ext)
+
+setup(
+    ext_modules=cythonize(
         raw_extensions,
         language_level=3,
         compiler_directives={"linetrace": CYTHON_LINETRACE},
-    )
-
-
-class sdist_krb5(sdist):
-    def run(self) -> None:
-        if not self.dry_run:
-            with open(SKIP_CYTHON_FILE, mode="wb") as flag_file:
-                flag_file.write(b"")
-
-            sdist.run(self)
-
-            os.remove(SKIP_CYTHON_FILE)
-
-
-setup(
-    name="krb5",
-    version="0.3.0",
-    packages=find_packages(where="src"),
-    package_data={
-        "krb5": ["py.typed", "*.pyi"],
-    },
-    package_dir={"": "src"},
-    py_modules=[os.path.splitext(os.path.basename(path))[0] for path in glob.glob("src/*.py")],
-    cmdclass={
-        "sdist": sdist_krb5,
-    },
-    ext_modules=extensions,
-    include_package_data=False,
-    install_requires=[],
-    extras_require={},
-    author="Jordan Borean",
-    author_email="jborean93@gmail.com",
-    url="https://github.com/jborean93/pykrb5",
-    description="Kerberos API bindings for Python",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    keywords="krb5 kerberos",
-    license="MIT",
-    python_requires=">=3.6",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-    ],
+    ),
 )


### PR DESCRIPTION
Migrates the project to be PEP 517 compliant by specifying the build
metadata and other configuration in the pyproject.toml file. The only
remaining code in the setup.py is the native extensions which need to
run when installing from an sdist.

Part of this change is also removing the cythonised files from the sdist
making Cython a build requirement. As this is specified in the build
metadata this should automatically be installed when pip is installing
from an sdist.

Fixes https://github.com/jborean93/pykrb5/issues/13