### PR TITLE
[pseudometric] add aname_to_localname(); fix bug in init_context()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -235,6 +235,7 @@ if not SKIP_EXTENSIONS:
         ("principal_heimdal", "krb5_principal_get_realm"),
         "string",
         ("string_mit", "krb5_enctype_to_name"),
+        "localauth",
     ]:
         name = e
         canary = None

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -57,6 +57,7 @@ from krb5._kt import (
     kt_remove_entry,
     kt_resolve,
 )
+from krb5._localauth import aname_to_localname
 from krb5._principal import (
     Principal,
     PrincipalParseFlags,
@@ -81,6 +82,7 @@ __all__ = [
     "Principal",
     "PrincipalParseFlags",
     "PrincipalUnparseFlags",
+    "aname_to_localname",
     "cc_default",
     "cc_default_name",
     "cc_destroy",

--- a/src/krb5/_context.pyx
+++ b/src/krb5/_context.pyx
@@ -60,8 +60,12 @@ cdef class Context:
 
 
 def init_context() -> Context:
+    cdef krb5_error_code = 0
     context = Context()
-    krb5_init_context(&context.raw)
+
+    err = krb5_init_context(&context.raw)
+    if err:
+        raise Krb5Error(context, err)
 
     return context
 

--- a/src/krb5/_localauth.pyi
+++ b/src/krb5/_localauth.pyi
@@ -1,0 +1,23 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from krb5._context import Context
+from krb5._principal import Principal
+
+def aname_to_localname(context: Context, principal: Principal) -> str:
+    """Translate a Kerberos principal to an authorization ID ("local name").
+
+    Using configured rules, translate a Kerberos principal name to a
+    string suitable for use in authorization rules; often, this means
+    mapping it to a username for the host OS. See krb5.conf(5)
+    "localauth interface" for details.
+
+    Args:
+          context: krb5 context
+        principal: principal name to translate
+
+    Returns:
+      str: translation
+     None: principal has no translation
+           (krb5_aname_to_localname() returns KRB5_LNAME_NOTRANS)
+    """

--- a/src/krb5/_localauth.pyx
+++ b/src/krb5/_localauth.pyx
@@ -1,0 +1,47 @@
+# Copyright: (c) 2022 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from libc.stdlib cimport free, malloc
+
+from krb5._exceptions import Krb5Error
+
+from krb5._context cimport Context
+from krb5._krb5_types cimport *
+from krb5._principal cimport Principal
+
+
+cdef extern from "python_krb5.h":
+
+    krb5_error_code krb5_aname_to_localname(
+        krb5_context context,
+        krb5_const_principal aname,
+        int lnsize,
+        char *lname_out
+    ) nogil
+
+    krb5_error_code KRB5_LNAME_NOTRANS
+
+def aname_to_localname(
+    context: Context,
+    principal: Principal
+) -> str:
+
+    cdef krb5_error_code err = 0
+    limit = 256
+
+    cdef char *localname = <char *>malloc(limit + 1)
+    if not localname:
+        raise MemoryError()
+
+    err = krb5_aname_to_localname(context.raw, principal.raw, limit, localname)
+    # The definition of KRB5_LNAME_NOTRANS in the Heimdal header file
+    # included in the pykrb5 source appears to be out of date; this is
+    # the value that actually gets returned in the test -- so I'm just
+    # adding it here for now.
+    if err in [KRB5_LNAME_NOTRANS, -1765328227]:
+        return None
+    elif err != 0:
+        free(localname)
+        raise Krb5Error(context, err)
+    else:
+        return localname.decode("utf-8")

--- a/tests/test_localauth.py
+++ b/tests/test_localauth.py
@@ -1,0 +1,63 @@
+# Copyright: (c) 2021 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+import os
+import tempfile
+from typing import Optional
+
+import k5test
+import pytest
+
+import krb5
+
+
+def test_aname_to_localname(realm: k5test.K5Realm) -> None:
+
+    # require: translation(p) == t
+    def test(ctx: krb5.Context, p: str, t: Optional[str]) -> None:
+        assert t == krb5.aname_to_localname(ctx, krb5.parse_name_flags(ctx, p.encode()))
+
+    # To test, apply our own krb5.conf with a single translation
+    # rule. The file is read by krb5_init_context(), so set the
+    # environment variable before calling that. This overrides the
+    # default rule, so only matching principals will have a
+    # translation. Require a 2-instance name in the realm TEST.
+    #
+    # ... that's for MIT. Heimdal doesn't appear to have RULE
+    # translations built in, so use auth_to_local_names instead.
+    #
+    # Since environment variables are process-wide, this could mess up
+    # other tests in a multi-threaded test framework -- but that
+    # probably won't be an issue here.
+
+    with tempfile.NamedTemporaryFile() as config:
+        saved_conf = os.environ.get("KRB5_CONFIG")
+        try:
+            config.write(
+                b"""
+[libdefaults]
+default_realm = TEST
+
+[realms]
+TEST = {
+  auth_to_local = RULE:[2:$1:$2@$0](^.*@TEST$)s/@TEST$//
+  auth_to_local_names = {
+     heimdal = mapped
+  }
+}
+            """
+            )
+            config.flush()
+            os.environ["KRB5_CONFIG"] = config.name
+            ctx = krb5.init_context()
+            if realm.provider == "mit":
+                test(ctx, "foo/bar@TEST", "foo:bar")
+                test(ctx, "foo@TEST", None)
+                test(ctx, "foo/bar@WRONG", None)
+            if realm.provider == "heimdal":
+                test(ctx, "heimdal", "mapped")
+        finally:
+            if saved_conf:
+                os.environ["KRB5_CONFIG"] = saved_conf
+            else:
+                del os.environ["KRB5_CONFIG"]


### PR DESCRIPTION
1. check for errors returned from `krb5_init_context()`
2. add glue call to `krb5_aname_to_localname()`

Thanks for writing this; it looks like it will be quite useful for us!

– Richard Silverman <res@arcesium.com>
