### PR TITLE
Fix handling of krb5_data structs.

### DIFF
--- a/src/krb5/_creds.pyx
+++ b/src/krb5/_creds.pyx
@@ -159,7 +159,8 @@ cdef krb5_error_code prompt_callback(
             replies.append(reply)
 
         for idx, reply in enumerate(replies):
-            pykrb5_set_krb5_data(prompts[idx].reply, len(reply), <char *>reply)
+            if pykrb5_set_krb5_data(prompts[idx].reply, len(reply), <char *>reply) != 0:
+                raise Exception("[prompter callback] Our reply is too big for the caller's buffer.")
 
         return 0
 


### PR DESCRIPTION
The caller (at least, MIT Kerberos) expects us to return our data in an existing buffer referred to by the `krb5_data` struct we get, rather than *update* that struct with a new buffer of our own.

I ran into this when using pykrb5 with PKINIT, and needed to supply a passphrase for the client's private key via a `Krb5Prompt` object. It mysteriously failed to decrypt the key even though the passphrase returned by the prompter was right. Eventually I tracked it down to [pkinit_crypto_openssl.c](https://github.com/krb5/krb5/blob/30429ade54bfe66f9145a30487e43b19bde76701/src/plugins/preauth/pkinit/pkinit_crypto_openssl.c#L1196). This:

    rdat.data = buf;
    rdat.length = size;

is where it sets the `krb5_data rdat` it will pass to us to refer to its own buffer, and if you follow the code you see that it expects the returned data to be in `buf`. We were instead returning an updated `rdat.data`, which it never looks at. I was getting this `KRB5_TRACE`:

    PKINIT OpenSSL error: error:0906A068:PEM routines:PEM_do_header:bad password read

(which is actually itself a minor bug; it should say "bad decryption"). With this fix, the PKINIT succeeds.

Since it is now possible for `pykrb5_set_krb5_data()` to fail if the caller's buffer is not big enough, I changed its signature and raise an exception in this case; I'm not sure if that's done as you would want. Ideally we should come up with a test to catch this; I assume it wasn't caught because it's mocked in the tests, but I haven't looked closely at that yet. And, a good question is: does Heimdal have the same calling convention for this?