### PR TITLE
Have `krb5.init_context()` raise an exception on error.

### DIFF
--- a/src/krb5/_context.pyx
+++ b/src/krb5/_context.pyx
@@ -60,8 +60,12 @@ cdef class Context:
 
 
 def init_context() -> Context:
+    cdef krb5_error_code = 0
     context = Context()
-    krb5_init_context(&context.raw)
+
+    err = krb5_init_context(&context.raw)
+    if err:
+        raise Krb5Error(context, err)
 
     return context
 


### PR DESCRIPTION
`krb5.init_context()` currently just returns a null pointer if the C routine fails, which is unlike the norm in this module and I assume is an oversight. Typically this will fail if there's a syntax error in the libkrb5 configuration (`/etc/krb5.conf`, or whatever is read). A program using pykrb5 that I wrote segfaulted in this situation, because I then passed the null context to other routines. With this change, we get instead:
```
In [2]: ctx = krb5.init_context()
---------------------------------------------------------------------------
Krb5Error                                 Traceback (most recent call last)
...
Krb5Error: Included profile file could not be read -1429577697
```