### PR TITLE
Move back to using setup.cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,8 +150,6 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-python@v4
-
     - uses: actions/download-artifact@v3
       with:
         name: artifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.5.0 - TBD
 
+* Added exception that is raised when `krb5.init_context()` failed
+* Moved back to `setup.cfg` based setuptools project for compatibility with `pip` present on system distributions
+
 ## 0.4.1 - 2022-10-25
 
 * Added Python 3.11 wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,46 +1,14 @@
 [build-system]
 requires = [
     "Cython >= 0.29.29, < 3.0.0",  # 0.29.29 includes fixes for Python 3.11
-    "setuptools >= 61.0.0",  # Support for setuptools config in pyproject.toml
+    "setuptools >= 42.0.0",  # Supports license_files
 ]
 build-backend = "setuptools.build_meta"
 
-[project]
-name = "krb5"
-version = "0.5.0"
-description = "Kerberos API bindings for Python"
-readme = "README.md"
-requires-python = ">=3.7"
-license = {file = "LICENSE"}
-authors = [
-    { name = "Jordan Borean", email = "jborean93@gmail.com" }
-]
-keywords = ["krb5", "kerberos"]
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "License :: OSI Approved :: MIT License",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
-]
-
-[project.urls]
-homepage = "https://github.com/jborean93/pykrb5"
-
-[tool.setuptools]
-include-package-data = true
-
-[tool.setuptools.packages.find]
-where = ["src"]
-
-[tool.setuptools.package-data]
-krb5 = ["py.typed", "*.pyi"]
-
-[tool.setuptools.exclude-package-data]
-krb5 = ["*.pxd", "*.pyx"]
+# FUTURE: Mandate newer setuptools to use pyproject.toml configuration
+# Currently it fails when using older pip versions that are still used by some
+# Linux distributions with:
+# WARNING: Generating metadata for package krb5 produced metadata for project name unknown. Fix your #egg=krb5 fragments.
 
 [tool.black]
 line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,43 @@
+[metadata]
+name = krb5
+version = 0.5.0
+url = https://github.com/jborean93/pykrb5
+author = Jordan Borean
+author_email = jborean93@gmail.com
+license = MIT
+license_files = LICENSE
+description = Kerberos API bindings for Python
+long_description = file: README.md
+long_description_content_type = text/markdown
+keywords =
+    krb5
+    kerberos
+classifiers =
+    Development Status :: 4 - Beta
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+
+[options]
+package_dir =
+    =src
+packages = find:
+include_package_data = True
+python_requires = >= 3.7
+
+[options.packages.find]
+where = src
+
+[options.package_data]
+krb5 =
+    py.typed
+    *.pyi
+
+[options.exclude_package_data]
+krb5 =
+    *.pxd
+    *.pyx


### PR DESCRIPTION
Unfortunately due to some incompatibilities with pip and newer setuptools versions that introduced support for project definitions in the pyproject.toml this commit goes back to using the older setup.cfg definition. This ensures the project can be compiled from the sdist in more scenarios. At some point in the future this should be revisited when hosts come with newer pip versions.