### PR TITLE
Declare the function as noexcept when it is not raising exception.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "Cython >= 0.29.31, < 3.0.0",  # 0.29.31 includes noexcept keyword support
+    "Cython >= 0.29.32, < 3.0.0",  # 0.29.31 includes noexcept keyword support
     "setuptools >= 42.0.0",  # Supports license_files
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "Cython >= 0.29.29, < 3.0.0",  # 0.29.29 includes fixes for Python 3.11
+    "Cython >= 0.29.31, < 3.0.0",  # 0.29.31 includes noexcept keyword support
     "setuptools >= 42.0.0",  # Supports license_files
 ]
 build-backend = "setuptools.build_meta"

--- a/src/krb5/_creds.pyx
+++ b/src/krb5/_creds.pyx
@@ -263,7 +263,7 @@ cdef krb5_error_code prompt_callback(
     const char *banner,
     int num_prompts,
     krb5_prompt *prompts,
-) with gil:
+) noexcept with gil:
     try:
         prompter = <Krb5Prompt>data
 


### PR DESCRIPTION
Cython 3 will require noexcept keyword in the declaraction of the function not raising
an exceptions. See https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#exception-values-and-noexcept

Fixes #26
