### PR TITLE
Exclude header files from package data

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,4 @@ krb5 =
 krb5 =
     *.pxd
     *.pyx
+    *.h


### PR DESCRIPTION
While working on packaging this library for Fedora, we noticed that python_krb5.h is installed in the site-packages directory.  I think it should be excluded, similar to how *.pxd and *.pyx files are.

https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2238652