### PR TITLE
Creds serialization and deserialization

### DIFF
--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -172,12 +172,14 @@ else:
 
 
 try:
-    from krb5._creds_mit import get_etype_info, get_validated_creds
+    from krb5._creds_mit import get_etype_info, get_validated_creds, serialize_creds, unserialize_creds
 except ImportError:
     pass
 else:
     __all__.append("get_etype_info")
     __all__.append("get_validated_creds")
+    __all__.append("serialize_creds")
+    __all__.append("unserialize_creds")
 
 
 try:

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -175,16 +175,16 @@ try:
     from krb5._creds_mit import (
         get_etype_info,
         get_validated_creds,
-        serialize_creds,
-        unserialize_creds,
+        marshal_credentials,
+        unmarshal_credentials,
     )
 except ImportError:
     pass
 else:
     __all__.append("get_etype_info")
     __all__.append("get_validated_creds")
-    __all__.append("serialize_creds")
-    __all__.append("unserialize_creds")
+    __all__.append("marshal_credentials")
+    __all__.append("unmarshal_credentials")
 
 
 try:

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -172,7 +172,12 @@ else:
 
 
 try:
-    from krb5._creds_mit import get_etype_info, get_validated_creds, serialize_creds, unserialize_creds
+    from krb5._creds_mit import (
+        get_etype_info,
+        get_validated_creds,
+        serialize_creds,
+        unserialize_creds,
+    )
 except ImportError:
     pass
 else:

--- a/src/krb5/_creds.pxd
+++ b/src/krb5/_creds.pxd
@@ -8,6 +8,7 @@ from krb5._krb5_types cimport *
 cdef class Creds:
     cdef Context ctx
     cdef krb5_creds raw
+    cdef krb5_creds* _raw_ptr
     cdef int needs_free
 
 

--- a/src/krb5/_creds_mit.pyi
+++ b/src/krb5/_creds_mit.pyi
@@ -48,3 +48,25 @@ def get_etype_info(
 
         If there are no s2kparams in the provided etype-info, s2kparams is None.
     """
+
+def serialize_creds(context: Context, creds: Creds) -> bytes:
+    """Serialize creds in the format used by the FILE ccache format
+    (vesion 4) and KCM ccache protocol.
+
+    Args:
+        creds: Credentials to serialize.
+
+    Returns:
+        bytes: The serialized credentials.
+    """
+
+def unserialize_creds(context: Context, data: bytes) -> Creds:
+    """Deserialize creds from the format used by the FILE ccache format
+    (vesion 4) and KCM ccache protocol.
+
+    Args:
+        context: Krb5 context.
+        data: serialized credentials.
+    Returns:
+        Creds: The unserialized credentials.
+    """

--- a/src/krb5/_creds_mit.pyi
+++ b/src/krb5/_creds_mit.pyi
@@ -49,18 +49,19 @@ def get_etype_info(
         If there are no s2kparams in the provided etype-info, s2kparams is None.
     """
 
-def serialize_creds(context: Context, creds: Creds) -> bytes:
+def marshal_credentials(context: Context, creds: Creds) -> bytes:
     """Serialize creds in the format used by the FILE ccache format
     (vesion 4) and KCM ccache protocol.
 
     Args:
+        context: Krb5 context.
         creds: Credentials to serialize.
 
     Returns:
         bytes: The serialized credentials.
     """
 
-def unserialize_creds(context: Context, data: bytes) -> Creds:
+def unmarshal_credentials(context: Context, data: bytes) -> Creds:
     """Deserialize creds from the format used by the FILE ccache format
     (vesion 4) and KCM ccache protocol.
 

--- a/src/krb5/_creds_mit.pyx
+++ b/src/krb5/_creds_mit.pyx
@@ -6,6 +6,9 @@ import typing
 
 from krb5._exceptions import Krb5Error
 
+from libc.stdlib cimport free
+from libc.string cimport memcpy
+
 from krb5._ccache cimport CCache
 from krb5._context cimport Context
 from krb5._creds cimport Creds
@@ -13,8 +16,6 @@ from krb5._creds_opt cimport GetInitCredsOpt
 from krb5._krb5_types cimport *
 from krb5._principal cimport Principal
 
-from libc.stdlib cimport free
-from libc.string cimport memcpy
 
 cdef extern from "python_krb5.h":
     """

--- a/src/krb5/_creds_mit.pyx
+++ b/src/krb5/_creds_mit.pyx
@@ -6,7 +6,6 @@ import typing
 
 from krb5._exceptions import Krb5Error
 
-from libc.stdlib cimport free
 from libc.string cimport memcpy
 
 from krb5._ccache cimport CCache

--- a/tests/test_creds.py
+++ b/tests/test_creds.py
@@ -303,15 +303,15 @@ def test_creds_serialization(realm: k5test.K5Realm) -> None:
     assert isinstance(creds, krb5.Creds)
 
     with pytest.raises(krb5.Krb5Error):
-        krb5.unserialize_creds(ctx, b"invalid")
+        krb5.unmarshal_credentials(ctx, b"invalid")
 
     with pytest.raises(krb5.Krb5Error):
-        krb5.unserialize_creds(ctx, b"")
+        krb5.unmarshal_credentials(ctx, b"")
 
-    bytes = krb5.serialize_creds(ctx, creds)
+    bytes = krb5.marshal_credentials(ctx, creds)
     assert len(bytes) > 0
 
-    uncreds = krb5.unserialize_creds(ctx, bytes)
+    uncreds = krb5.unmarshal_credentials(ctx, bytes)
     assert isinstance(uncreds, krb5.Creds)
     assert str(uncreds) == "Creds"
 

--- a/tests/test_creds.py
+++ b/tests/test_creds.py
@@ -315,3 +315,6 @@ def test_creds_serialization(realm: k5test.K5Realm) -> None:
     assert str(uncreds) == "Creds"
     assert id(creds) != id(uncreds)
     assert creds.client.name == uncreds.client.name
+    assert creds.ticket == uncreds.ticket
+    assert creds.keyblock.data == uncreds.keyblock.data
+    assert creds.times.endtime == uncreds.times.endtime

--- a/tests/test_creds.py
+++ b/tests/test_creds.py
@@ -294,7 +294,7 @@ def test_get_etype_info(realm: k5test.K5Realm, tmp_path: pathlib.Path) -> None:
     assert creds.server.name == b"krbtgt/KRBTEST.COM@KRBTEST.COM"
 
 
-@pytest.mark.requires_api("serialize_creds")
+@pytest.mark.requires_api("marshal_credentials")
 def test_creds_serialization(realm: k5test.K5Realm) -> None:
     ctx = krb5.init_context()
     princ = krb5.parse_name_flags(ctx, realm.user_princ.encode())
@@ -312,7 +312,9 @@ def test_creds_serialization(realm: k5test.K5Realm) -> None:
     assert len(bytes) > 0
 
     uncreds = krb5.unserialize_creds(ctx, bytes)
+    assert isinstance(uncreds, krb5.Creds)
     assert str(uncreds) == "Creds"
+
     assert id(creds) != id(uncreds)
     assert creds.client.name == uncreds.client.name
     assert creds.ticket == uncreds.ticket


### PR DESCRIPTION
`Creds` (de)serialization to/from the FILE ccache format (vesion 4) and KCM ccache protocol.

Use case: loading/storing of `Creds` objects in implementation-external cache memory, with TTL aligned to ticket validity.

MIT only:
[krb5_marshal_credentials](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_marshal_credentials.html)
[krb5_unmarshal_credentials](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_unmarshal_credentials.html)

Example usage:
```py
bytes = krb5.marshal_credentials(ctx, creds)
uncreds = krb5.unmarshal_credentials(ctx, bytes)
```
