### PR TITLE
Cleanup cred implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   * MIT only
   * [krb5_get_etype_info](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_get_etype_info.html)
   * [krb5_get_validated_creds](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_get_validated_creds.html)
+  * MIT 1.20+ only
   * [krb5_marshal_credentials](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_marshal_credentials.html)
   * [krb5_unmarshal_credentials](https://web.mit.edu/kerberos/krb5-devel/doc/appdev/refs/api/krb5_unmarshal_credentials.html)
 * Added KeyBlock APIs:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Due to the complex nature of this API it is highly recommended to use something 
 ## Requirements
 
 * An implementation of the Kerberos 5 API - including the header files
-  * [MIT Kebreros](https://web.mit.edu/kerberos/)
+  * [MIT Kebreros](https://web.mit.edu/kerberos/) - Minimum 1.17
   * [Heimdal](https://github.com/heimdal/heimdal)
 * A C compiler, such as GCC
 * Python 3.6+

--- a/setup.py
+++ b/setup.py
@@ -220,6 +220,7 @@ if not SKIP_EXTENSIONS:
         "context",
         ("context_mit", "krb5_init_secure_context"),
         "creds",
+        ("creds_marshal_mit", "krb5_marshal_credentials"),
         ("creds_mit", "krb5_get_etype_info"),
         "creds_opt",
         ("creds_opt_heimdal", "krb5_get_init_creds_opt_set_default_flags"),

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -172,17 +172,18 @@ else:
 
 
 try:
-    from krb5._creds_mit import (
-        get_etype_info,
-        get_validated_creds,
-        marshal_credentials,
-        unmarshal_credentials,
-    )
+    from krb5._creds_mit import get_etype_info, get_validated_creds
 except ImportError:
     pass
 else:
     __all__.append("get_etype_info")
     __all__.append("get_validated_creds")
+
+try:
+    from krb5._creds_marshal_mit import marshal_credentials, unmarshal_credentials
+except ImportError:
+    pass
+else:
     __all__.append("marshal_credentials")
     __all__.append("unmarshal_credentials")
 

--- a/src/krb5/_ccache.pyx
+++ b/src/krb5/_ccache.pyx
@@ -200,7 +200,7 @@ cdef class CCache:
                     self.ctx.raw,
                     self.raw,
                     &cursor,
-                    creds.__c_value__(),
+                    creds.get_pointer(),
                 )
                 if err:
                     break
@@ -359,7 +359,7 @@ def cc_remove_cred(
         context.raw,
         cache.raw,
         flags,
-        creds.__c_value__(),
+        creds.get_pointer(),
     )
     if err:
         raise Krb5Error(context, err)
@@ -398,8 +398,8 @@ def cc_retrieve_cred(
         context.raw,
         cache.raw,
         flags,
-        mcreds.__c_value__(),
-        creds.__c_value__())
+        mcreds.get_pointer(),
+        creds.get_pointer())
     if err:
         raise Krb5Error(context, err)
 
@@ -430,7 +430,7 @@ def cc_store_cred(
 ) -> None:
     cdef krb5_error_code err = 0
 
-    err = krb5_cc_store_cred(context.raw, cache.raw, creds.__c_value__())
+    err = krb5_cc_store_cred(context.raw, cache.raw, creds.get_pointer())
     if err:
         raise Krb5Error(context, err)
 

--- a/src/krb5/_creds.pxd
+++ b/src/krb5/_creds.pxd
@@ -12,7 +12,7 @@ cdef class Creds:
     cdef int _free_raw
 
     cdef void* set_raw_from_lib(Creds self, krb5_creds* raw)
-    cdef krb5_creds *__c_value__(Creds self)
+    cdef krb5_creds *get_pointer(Creds self)
 
 
 cdef class InitCredsContext:

--- a/src/krb5/_creds.pxd
+++ b/src/krb5/_creds.pxd
@@ -7,9 +7,12 @@ from krb5._krb5_types cimport *
 
 cdef class Creds:
     cdef Context ctx
-    cdef krb5_creds raw
-    cdef krb5_creds* _raw_ptr
-    cdef int needs_free
+    cdef int free_contents
+    cdef krb5_creds* _raw
+    cdef int _free_raw
+
+    cdef void* set_raw_from_lib(Creds self, krb5_creds* raw)
+    cdef krb5_creds *__c_value__(Creds self)
 
 
 cdef class InitCredsContext:

--- a/src/krb5/_creds_marshal_mit.pyi
+++ b/src/krb5/_creds_marshal_mit.pyi
@@ -1,0 +1,45 @@
+# Copyright: (c) 2024 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from __future__ import annotations
+
+from krb5._context import Context
+from krb5._creds import Creds
+
+def marshal_credentials(
+    context: Context,
+    creds: Creds,
+) -> bytes:
+    """Serialize creds.
+
+    Serialize credentials in the format used by the FILE ccache format
+    (version 4) and KCM ccache protocol.
+
+    This is only present when compiled against MIT 1.20 or newer.
+
+    Args:
+        context: Krb5 context.
+        creds: Credentials to serialize.
+
+    Returns:
+        bytes: The serialized credentials.
+    """
+
+def unmarshal_credentials(
+    context: Context,
+    data: bytes,
+) -> Creds:
+    """Deserialize creds.
+
+    Deserialize credentials from the format used by the FILE ccache format
+    (version 4) and KCM ccache protocol.
+
+    This is only present when compiled against MIT 1.20 or newer.
+
+    Args:
+        context: Krb5 context.
+        data: serialized credentials.
+
+    Returns:
+        Creds: The unserialized credentials.
+    """

--- a/src/krb5/_creds_marshal_mit.pyx
+++ b/src/krb5/_creds_marshal_mit.pyx
@@ -1,0 +1,86 @@
+# Copyright: (c) 2021 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+# These APIs were added in MIT 1.20, to be compat with 1.18 we need to define
+# them separately.
+
+import collections
+import typing
+
+from krb5._exceptions import Krb5Error
+
+from krb5._ccache cimport CCache
+from krb5._context cimport Context
+from krb5._creds cimport Creds
+from krb5._creds_opt cimport GetInitCredsOpt
+from krb5._krb5_types cimport *
+from krb5._principal cimport Principal
+
+
+cdef extern from "python_krb5.h":
+    krb5_error_code krb5_marshal_credentials(
+        krb5_context context,
+        krb5_creds *creds,
+        krb5_data **data
+    ) nogil
+
+    krb5_error_code krb5_unmarshal_credentials(
+        krb5_context context,
+        krb5_data *data,
+        krb5_creds **creds,
+    ) nogil
+
+    void krb5_free_data(
+        krb5_context context,
+        krb5_data *val,
+    ) nogil
+
+def marshal_credentials(
+    Context context not None,
+    Creds creds not None,
+) -> bytes:
+    cdef krb5_error_code err = 0
+    cdef krb5_data *data = NULL
+    cdef size_t length
+    cdef char *value
+
+    try:
+        err = krb5_marshal_credentials(context.raw, creds.__c_value__(), &data)
+
+        if err:
+            raise Krb5Error(context, err)
+
+        pykrb5_get_krb5_data(data, &length, &value)
+
+        if length == 0:
+            data_bytes = b""
+        else:
+            data_bytes = value[:length]
+
+        return data_bytes
+
+    finally:
+        if NULL != data:
+            krb5_free_data(context.raw, data)
+
+def unmarshal_credentials(
+    Context context not None,
+    const unsigned char[:] data not None,
+) -> Creds:
+    cdef krb5_error_code err = 0
+    cdef krb5_creds* raw_creds = NULL
+    cdef krb5_data data_raw
+
+    if len(data) == 0:
+        pykrb5_set_krb5_data(&data_raw, 0, "")
+    else:
+        pykrb5_set_krb5_data(&data_raw, len(data), <char *>&data[0])
+
+    err = krb5_unmarshal_credentials(context.raw, &data_raw, &raw_creds)
+    if err:
+        raise Krb5Error(context, err)
+
+    creds = Creds(context)
+    creds.set_raw_from_lib(raw_creds)
+
+    return creds

--- a/src/krb5/_creds_marshal_mit.pyx
+++ b/src/krb5/_creds_marshal_mit.pyx
@@ -45,7 +45,7 @@ def marshal_credentials(
     cdef char *value
 
     try:
-        err = krb5_marshal_credentials(context.raw, creds.__c_value__(), &data)
+        err = krb5_marshal_credentials(context.raw, creds.get_pointer(), &data)
 
         if err:
             raise Krb5Error(context, err)

--- a/src/krb5/_creds_mit.pyi
+++ b/src/krb5/_creds_mit.pyi
@@ -48,37 +48,3 @@ def get_etype_info(
 
         If there are no s2kparams in the provided etype-info, s2kparams is None.
     """
-
-def marshal_credentials(
-    context: Context,
-    creds: Creds,
-) -> bytes:
-    """Serialize creds.
-
-    Serialize credentials in the format used by the FILE ccache format
-    (version 4) and KCM ccache protocol.
-
-    Args:
-        context: Krb5 context.
-        creds: Credentials to serialize.
-
-    Returns:
-        bytes: The serialized credentials.
-    """
-
-def unmarshal_credentials(
-    context: Context,
-    data: bytes,
-) -> Creds:
-    """Deserialize creds.
-
-    Deserialize credentials from the format used by the FILE ccache format
-    (version 4) and KCM ccache protocol.
-
-    Args:
-        context: Krb5 context.
-        data: serialized credentials.
-
-    Returns:
-        Creds: The unserialized credentials.
-    """

--- a/src/krb5/_creds_mit.pyx
+++ b/src/krb5/_creds_mit.pyx
@@ -6,8 +6,6 @@ import typing
 
 from krb5._exceptions import Krb5Error
 
-from libc.string cimport memcpy
-
 from krb5._ccache cimport CCache
 from krb5._context cimport Context
 from krb5._creds cimport Creds
@@ -17,16 +15,6 @@ from krb5._principal cimport Principal
 
 
 cdef extern from "python_krb5.h":
-    """
-#if defined(HEIMDAL_XFREE)
-#error "Heimdal implementation does not support MIT-specific calls:"
-#error " krb5_get_validated_creds()"
-#error " krb5_get_etype_info()"
-#error " krb5_marshal_credentials()"
-#error " krb5_unmarshal_credentials()"
-#endif
-    """
-
     krb5_error_code krb5_get_validated_creds(
         krb5_context context,
         krb5_creds *creds,
@@ -44,22 +32,11 @@ cdef extern from "python_krb5.h":
         krb5_data *s2kparams_ou,
     ) nogil
 
-    krb5_error_code krb5_marshal_credentials(
-        krb5_context context,
-        krb5_creds *creds,
-        krb5_data **data
-    ) nogil
-
-    krb5_error_code krb5_unmarshal_credentials(
-        krb5_context context,
-        krb5_data *data,
-        krb5_creds **creds,
-    ) nogil
-
-    void krb5_free_data(
-        krb5_context context,
-        krb5_data *val,
-    ) nogil
+EtypeInfo = collections.namedtuple('EtypeInfo', [
+    'etype',
+    'salt',
+    's2kparams',
+])
 
 def get_validated_creds(
     Context context not None,
@@ -74,11 +51,16 @@ def get_validated_creds(
     if in_tkt_service is not None and len(in_tkt_service):
         in_tkt_service_ptr = <const char*>&in_tkt_service[0]
 
-    err = krb5_get_validated_creds(context.raw, &creds.raw, client.raw, ccache.raw, in_tkt_service_ptr)
+    err = krb5_get_validated_creds(
+        context.raw,
+        creds.__c_value__(),
+        client.raw,
+        ccache.raw,
+        in_tkt_service_ptr)
     if err:
         raise Krb5Error(context, err)
 
-    creds.needs_free = 1
+    creds.free_contents = 1
 
     return creds
 
@@ -136,59 +118,3 @@ def get_etype_info(
     pykrb5_free_data_contents(context.raw, &s2kparams)
 
     return EtypeInfo(enctype, salt_bytes, s2kparams_bytes)
-
-EtypeInfo = collections.namedtuple('EtypeInfo', [
-    'etype',
-    'salt',
-    's2kparams',
-])
-
-def marshal_credentials(Context context not None, Creds creds not None) -> bytes:
-    cdef krb5_error_code err = 0
-    cdef krb5_data *data = NULL
-    cdef size_t length
-    cdef char *value
-
-    try:
-        err = krb5_marshal_credentials(context.raw, &creds.raw, &data)
-
-        if err:
-            raise Krb5Error(context, err)
-
-        pykrb5_get_krb5_data(data, &length, &value)
-
-        if length == 0:
-            data_bytes = b""
-        else:
-            data_bytes = value[:length]
-
-        return data_bytes
-
-    finally:
-        if NULL != data:
-            krb5_free_data(context.raw, data)
-
-def unmarshal_credentials(Context context not None, const unsigned char[:] data not None) -> Creds:
-    cdef krb5_error_code err = 0
-    cdef krb5_data data_raw
-
-    creds = Creds(context)
-
-    if len(data) == 0:
-        pykrb5_set_krb5_data(&data_raw, 0, "")
-    else:
-        pykrb5_set_krb5_data(&data_raw, len(data), <char *>&data[0])
-
-    err = krb5_unmarshal_credentials(context.raw, &data_raw, &creds._raw_ptr)
-
-    if creds._raw_ptr:
-        # creds_raw was calloc'ed for krb5_creds structure
-        # "shallow copy" the structure
-        memcpy(&creds.raw, creds._raw_ptr, sizeof(creds.raw))
-        # mark "deep copy" for future deallocation
-        creds.needs_free = 1
-
-    if err:
-        raise Krb5Error(context, err)
-
-    return creds

--- a/src/krb5/_creds_mit.pyx
+++ b/src/krb5/_creds_mit.pyx
@@ -53,7 +53,7 @@ def get_validated_creds(
 
     err = krb5_get_validated_creds(
         context.raw,
-        creds.__c_value__(),
+        creds.get_pointer(),
         client.raw,
         ccache.raw,
         in_tkt_service_ptr)

--- a/tests/test_creds.py
+++ b/tests/test_creds.py
@@ -308,10 +308,11 @@ def test_creds_serialization(realm: k5test.K5Realm) -> None:
     with pytest.raises(krb5.Krb5Error):
         krb5.unmarshal_credentials(ctx, b"")
 
-    bytes = krb5.marshal_credentials(ctx, creds)
-    assert len(bytes) > 0
+    marshalled_actual = krb5.marshal_credentials(ctx, creds)
+    assert isinstance(marshalled_actual, bytes)
+    assert len(marshalled_actual) > 0
 
-    uncreds = krb5.unmarshal_credentials(ctx, bytes)
+    uncreds = krb5.unmarshal_credentials(ctx, marshalled_actual)
     assert isinstance(uncreds, krb5.Creds)
     assert str(uncreds) == "Creds"
 


### PR DESCRIPTION
Cleans up the credential implementation to better handle the marshalling API. This includes splitting out those APIs into a separate pyx file as it was introduced in MIT krb5 1.20 and also unified how the krb5_creds value is stored in the Python object that represents it.