### PR TITLE
do not decode result_string returned by set_password

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = krb5
-version = 0.7.0.post51
+version = 0.7.0
 url = https://github.com/jborean93/pykrb5
 author = Jordan Borean
 author_email = jborean93@gmail.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = krb5
-version = 0.7.0
+version = 0.7.0.post51
 url = https://github.com/jborean93/pykrb5
 author = Jordan Borean
 author_email = jborean93@gmail.com

--- a/src/krb5/_set_password.pyi
+++ b/src/krb5/_set_password.pyi
@@ -15,18 +15,16 @@ class SetPasswordResult(typing.NamedTuple):
     KRB5_KPASSWD_HARDERROR (2) - Server error\n
     KRB5_KPASSWD_AUTHERROR (3) - Authentication error\n
     KRB5_KPASSWD_SOFTERROR (4) - Password change rejected\n
-    Note the `result_code_string` is a byte string.
 
     The `result_string` is a server protocol response that may contain useful
     information about password policy violations or other errors.
-    It is decoded as a `string` according to ``RFC 3244``
     """
 
     result_code: int
     """The library result code of the password change operation."""
     result_code_string: bytes
     """The byte string representation of the result code."""
-    result_string: str
+    result_string: bytes
     """Server response string"""
 
 def set_password(

--- a/src/krb5/_set_password.pyx
+++ b/src/krb5/_set_password.pyx
@@ -87,16 +87,16 @@ def set_password(
         if length == 0:
             result_code_bytes = b""
         else:
-            result_code_bytes = value[:length]
+            result_code_bytes = <bytes>value[:length]
 
         pykrb5_get_krb5_data(&result_string, &length, &value)
 
         if length == 0:
             result_string_bytes = b""
         else:
-            result_string_bytes = value[:length]
+            result_string_bytes = <bytes>value[:length]
 
-        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes.decode("utf-8"))
+        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes)
 
     finally:
         pykrb5_free_data_contents(context.raw, &result_code_string)
@@ -147,16 +147,16 @@ def set_password_using_ccache(
         if length == 0:
             result_code_bytes = b""
         else:
-            result_code_bytes = value[:length]
+            result_code_bytes = <bytes>value[:length]
 
         pykrb5_get_krb5_data(&result_string, &length, &value)
 
         if length == 0:
             result_string_bytes = b""
         else:
-            result_string_bytes = value[:length]
+            result_string_bytes = <bytes>value[:length]
 
-        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes.decode("utf-8"))
+        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes)
 
     finally:
         pykrb5_free_data_contents(context.raw, &result_code_string)

--- a/tests/test_changepw.py
+++ b/tests/test_changepw.py
@@ -45,12 +45,12 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, empty_password.encode())
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, weak_password.encode())
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, new_password.encode())
     assert result_code == 0
@@ -91,14 +91,14 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     )
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
         ctx, cc, weak_password.encode(), princ
     )
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
         ctx, cc, new_password.encode(), princ


### PR DESCRIPTION
Field testing of `set_password()` with latest MIT and real AD introduced a potential decryption error of `result_string` which comes from server in encrypted format. 
The decryption works fine with k5test.
The root cause of this problem remains unclear (may be a native library, cipher negotiation issue, etc).
Until it is resolved, the Python code at least should not crash. 
Thus I propose to not decode the string and leave as is.
