### PR TITLE
set_password extended server response processing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = krb5
-version = 0.7.0.post51
+version = 0.7.0
 url = https://github.com/jborean93/pykrb5
 author = Jordan Borean
 author_email = jborean93@gmail.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = krb5
-version = 0.7.0
+version = 0.7.0.post51
 url = https://github.com/jborean93/pykrb5
 author = Jordan Borean
 author_email = jborean93@gmail.com

--- a/setup.py
+++ b/setup.py
@@ -217,6 +217,7 @@ if not SKIP_EXTENSIONS:
         ("ccache_match", "krb5_cc_cache_match"),
         ("ccache_support_switch", "krb5_cc_support_switch"),
         "cccol",
+        ("chpw_message_mit", "krb5_chpw_message"),
         "context",
         ("context_mit", "krb5_init_secure_context"),
         "creds",

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -85,7 +85,9 @@ from krb5._principal import (
 )
 from krb5._set_password import (
     ADPolicyInfo,
+    ADPolicyInfoProp,
     SetPasswordResult,
+    SetPasswordResultCode,
     set_password,
     set_password_using_ccache,
 )
@@ -93,6 +95,7 @@ from krb5._string import enctype_to_string, string_to_enctype
 
 __all__ = [
     "ADPolicyInfo",
+    "ADPolicyInfoProp",
     "CCache",
     "Context",
     "CredentialsRetrieveFlags",
@@ -109,6 +112,7 @@ __all__ = [
     "PrincipalParseFlags",
     "PrincipalUnparseFlags",
     "SetPasswordResult",
+    "SetPasswordResultCode",
     "TicketFlags",
     "TicketTimes",
     "build_principal",

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -1,6 +1,7 @@
 # Copyright: (c) 2021 Jordan Borean (@jborean93) <jborean93@gmail.com>
 # MIT License (see LICENSE or https://opensource.org/licenses/MIT)
 
+from krb5._adpi import ADPolicyInfo, ADPolicyInfoProp
 from krb5._ccache import (
     CCache,
     CredentialsRetrieveFlags,
@@ -84,8 +85,6 @@ from krb5._principal import (
     unparse_name_flags,
 )
 from krb5._set_password import (
-    ADPolicyInfo,
-    ADPolicyInfoProp,
     SetPasswordResult,
     SetPasswordResultCode,
     set_password,

--- a/src/krb5/__init__.py
+++ b/src/krb5/__init__.py
@@ -84,6 +84,7 @@ from krb5._principal import (
     unparse_name_flags,
 )
 from krb5._set_password import (
+    ADPolicyInfo,
     SetPasswordResult,
     set_password,
     set_password_using_ccache,
@@ -91,6 +92,7 @@ from krb5._set_password import (
 from krb5._string import enctype_to_string, string_to_enctype
 
 __all__ = [
+    "ADPolicyInfo",
     "CCache",
     "Context",
     "CredentialsRetrieveFlags",
@@ -194,6 +196,13 @@ except ImportError:
 else:
     __all__.append("marshal_credentials")
     __all__.append("unmarshal_credentials")
+
+try:
+    from krb5._chpw_message_mit import chpw_message
+except ImportError:
+    pass
+else:
+    __all__.append("chpw_message")
 
 
 try:

--- a/src/krb5/_adpi.py
+++ b/src/krb5/_adpi.py
@@ -69,23 +69,3 @@ class ADPolicyInfo(typing.NamedTuple):
             min_age=min_age,
             properties=ADPolicyInfoProp(flags),
         )
-
-    @classmethod
-    def to_bytes(cls, policy: "ADPolicyInfo") -> bytes:
-        """Reverses the `from_bytes` operation
-
-        Args:
-            policy: AD policy result structure
-
-        Returns:
-            bytes: Serialized AD policy result byte string
-        """
-        return struct.pack(
-            FORMAT,
-            0x0000,
-            policy.min_length,
-            policy.history,
-            int(policy.properties),
-            policy.max_age,
-            policy.min_age,
-        )

--- a/src/krb5/_adpi.py
+++ b/src/krb5/_adpi.py
@@ -1,0 +1,91 @@
+import enum
+import struct
+import typing
+
+FORMAT = "!HIIIQQ"
+
+
+class ADPolicyInfoProp(enum.IntFlag):
+    COMPLEX = 0x00000001
+    NO_ANON_CHANGEv = 0x00000002
+    NO_CLEAR_CHANGE = 0x00000004
+    LOCKOUT_ADMINS = 0x00000008
+    STORE_CLEARTEXT = 0x00000010
+    REFUSE_CHANGE = 0x00000020
+
+
+class ADPolicyInfo(typing.NamedTuple):
+    """The structure containing the reasons for failed password change attempt.
+    Should be used to inform the end user how to meet the policy requirements.
+    This is specific to Active Directory and is returned as the
+    `server_response` by :meth:`set_password()` and
+    :meth:`set_password_using_ccache()`.
+
+    When using MIT library, this structure may be encoded back to bytes and
+    passed to :meth:`chpw_message()` to obtain a human readable response.
+    With Heimdal, it is required to provide a custom implementation based
+    on the known fields below.
+
+    The structure contains the following fields:\n
+    - `properties` - Password policy bit flags (see below)
+    - `min_length` - Minimal password length
+    - `history`    - Number of passwords that this system remembers
+    - `max_age`    - Maximum password age in 100 nanosecond units
+    - `min_age`    - Minimum password age in 100 nanosecond units
+
+    The only known property flag is `COMPLEX` which means that the password must
+    meet certain character variety and not contain the user's name.
+    To convert `max_age` and `min_age` to seconds, divide them by 10,000,000.
+    """
+
+    properties: ADPolicyInfoProp
+    min_length: int
+    history: int
+    max_age: int
+    min_age: int
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "ADPolicyInfo":
+        """Decode AD policy result from byte string
+
+        Args:
+            data: Serialized AD policy `server_response`
+
+        Returns:
+            ADPolicyInfo: Decoded AD policy result strcture
+
+        Raises:
+            ValueError: Invalid data length or wrong signature
+        """
+        if len(data) != struct.calcsize(FORMAT):
+            raise ValueError("Invalid data length")
+        signature, min_length, history, flags, max_age, min_age = struct.unpack(FORMAT, data)
+        if signature != 0x0000:
+            raise ValueError("Invalid signature")
+        return cls(
+            min_length=min_length,
+            history=history,
+            max_age=max_age,
+            min_age=min_age,
+            properties=ADPolicyInfoProp(flags),
+        )
+
+    @classmethod
+    def to_bytes(cls, policy: "ADPolicyInfo") -> bytes:
+        """Reverses the `from_bytes` operation
+
+        Args:
+            policy: AD policy result structure
+
+        Returns:
+            bytes: Serialized AD policy result byte string
+        """
+        return struct.pack(
+            FORMAT,
+            0x0000,
+            policy.min_length,
+            policy.history,
+            int(policy.properties),
+            policy.max_age,
+            policy.min_age,
+        )

--- a/src/krb5/_chpw_message_mit.pyi
+++ b/src/krb5/_chpw_message_mit.pyi
@@ -10,7 +10,9 @@ def chpw_message(context: Context, server_response: bytes) -> str:
     :meth:`to_bytes()`.
 
     Note that `gettext` library is used to translate the strings according
-    to locale settings.
+    to locale settings. For the list of existing translations, pls. refer
+    to MIT krb5 source code. Not all translations may be available on your
+    system.
 
     Args:
         context: Krb5 context.

--- a/src/krb5/_chpw_message_mit.pyi
+++ b/src/krb5/_chpw_message_mit.pyi
@@ -1,0 +1,17 @@
+from krb5._context import Context
+
+def chpw_message(context: Context, server_string: bytes) -> str:
+    """This function processes the server response returned as the
+    `result_string` of `krb5_change_password()`, `krb5_set_password()`, and
+    related functions, and returns a displayable string.
+    If server_string contains Active Directory structured policy information,
+    it will be converted into human-readable text.
+    Note the `gettext` library is used to translate the strings.
+
+    Args:
+        context: Krb5 context.
+        server_string: The `result_string` received from the KDC.
+
+    Returns:
+        str: The human readable reason string, locale sensitive.
+    """

--- a/src/krb5/_chpw_message_mit.pyi
+++ b/src/krb5/_chpw_message_mit.pyi
@@ -1,23 +1,24 @@
 from krb5._context import Context
 
-def chpw_message(context: Context, server_response: bytes) -> str:
+def chpw_message(context: Context, server_response: bytes) -> bytes:
     """This function processes the byte sequence returned as the
     `server_response` by :meth:`set_password()` and
     :meth:`set_password_using_ccache()` functions, and returns a human readable
-    string.
-
-    To pass the `ADPolicyInfo` structure to this function, encode it with
-    :meth:`to_bytes()`.
+    byte string.
 
     Note that `gettext` library is used to translate the strings according
     to locale settings. For the list of existing translations, pls. refer
     to MIT krb5 source code. Not all translations may be available on your
-    system.
+    system. Caller is responsible for decoding the string according to
+    locale settings.
+
+    To pass the `ADPolicyInfo` structure to this function, encode it with
+    :meth:`to_bytes()`.
 
     Args:
         context: Krb5 context.
         server_response: The `server_response` bytes received from the KDC.
 
     Returns:
-        str: The human readable reason string, locale sensitive.
+        bytes: The human readable bytes string.
     """

--- a/src/krb5/_chpw_message_mit.pyi
+++ b/src/krb5/_chpw_message_mit.pyi
@@ -12,9 +12,6 @@ def chpw_message(context: Context, server_response: bytes) -> bytes:
     system. Caller is responsible for decoding the string according to
     locale settings.
 
-    To pass the `ADPolicyInfo` structure to this function, encode it with
-    :meth:`to_bytes()`.
-
     Args:
         context: Krb5 context.
         server_response: The `server_response` bytes received from the KDC.

--- a/src/krb5/_chpw_message_mit.pyi
+++ b/src/krb5/_chpw_message_mit.pyi
@@ -1,16 +1,20 @@
 from krb5._context import Context
 
-def chpw_message(context: Context, server_string: bytes) -> str:
-    """This function processes the server response returned as the
-    `result_string` of `krb5_change_password()`, `krb5_set_password()`, and
-    related functions, and returns a displayable string.
-    If server_string contains Active Directory structured policy information,
-    it will be converted into human-readable text.
-    Note the `gettext` library is used to translate the strings.
+def chpw_message(context: Context, server_response: bytes) -> str:
+    """This function processes the byte sequence returned as the
+    `server_response` by :meth:`set_password()` and
+    :meth:`set_password_using_ccache()` functions, and returns a human readable
+    string.
+
+    To pass the `ADPolicyInfo` structure to this function, encode it with
+    :meth:`to_bytes()`.
+
+    Note that `gettext` library is used to translate the strings according
+    to locale settings.
 
     Args:
         context: Krb5 context.
-        server_string: The `result_string` received from the KDC.
+        server_response: The `server_response` bytes received from the KDC.
 
     Returns:
         str: The human readable reason string, locale sensitive.

--- a/src/krb5/_chpw_message_mit.pyx
+++ b/src/krb5/_chpw_message_mit.pyx
@@ -1,3 +1,4 @@
+import locale
 import typing
 
 from krb5._exceptions import Krb5Error
@@ -45,7 +46,7 @@ def chpw_message(
         else:
             message_len = strlen(message_out)
             message_bytes = <bytes>message_out[:message_len]
-            return  message_bytes.decode("utf-8")
+            return  message_bytes.decode(locale.getencoding())
 
     finally:
         krb5_free_string(context.raw, message_out)

--- a/src/krb5/_chpw_message_mit.pyx
+++ b/src/krb5/_chpw_message_mit.pyx
@@ -1,9 +1,12 @@
 import typing
+
 from krb5._exceptions import Krb5Error
+
+from libc.string cimport strlen
 
 from krb5._context cimport Context
 from krb5._krb5_types cimport *
-from libc.string cimport strlen
+
 
 cdef extern from "python_krb5.h":
     krb5_error_code krb5_chpw_message(

--- a/src/krb5/_chpw_message_mit.pyx
+++ b/src/krb5/_chpw_message_mit.pyx
@@ -15,7 +15,6 @@ cdef extern from "python_krb5.h":
         char **message_out
     ) nogil
 
-cdef extern from "python_krb5.h":
     void krb5_free_string(
         krb5_context context,
         char *string

--- a/src/krb5/_chpw_message_mit.pyx
+++ b/src/krb5/_chpw_message_mit.pyx
@@ -1,0 +1,48 @@
+import typing
+from krb5._exceptions import Krb5Error
+
+from krb5._context cimport Context
+from krb5._krb5_types cimport *
+from libc.string cimport strlen
+
+cdef extern from "python_krb5.h":
+    krb5_error_code krb5_chpw_message(
+        krb5_context context,
+        const krb5_data *server_string,
+        char **message_out
+    ) nogil
+
+cdef extern from "python_krb5.h":
+    void krb5_free_string(
+        krb5_context context,
+        char *string
+    ) nogil
+
+def chpw_message(
+    Context context not None,
+    const unsigned char[:] server_string not None,
+) -> str:
+    cdef krb5_error_code err = 0
+    cdef krb5_data server_string_raw
+    cdef char *message_out = NULL
+
+    try:
+        if len(server_string) == 0:
+            pykrb5_set_krb5_data(&server_string_raw, 0, "")
+        else:
+            pykrb5_set_krb5_data(&server_string_raw, len(server_string), <char *>&server_string[0])
+
+        err = krb5_chpw_message(context.raw, &server_string_raw, &message_out)
+
+        if err:
+            raise Krb5Error(context, err)
+
+        if message_out is NULL:
+            return ""
+        else:
+            message_len = strlen(message_out)
+            message_bytes = <bytes>message_out[:message_len]
+            return  message_bytes.decode("utf-8")
+
+    finally:
+        krb5_free_string(context.raw, message_out)

--- a/src/krb5/_chpw_message_mit.pyx
+++ b/src/krb5/_chpw_message_mit.pyx
@@ -1,4 +1,3 @@
-import locale
 import typing
 
 from krb5._exceptions import Krb5Error
@@ -25,7 +24,7 @@ cdef extern from "python_krb5.h":
 def chpw_message(
     Context context not None,
     const unsigned char[:] server_string not None,
-) -> str:
+) -> bytes:
     cdef krb5_error_code err = 0
     cdef krb5_data server_string_raw
     cdef char *message_out = NULL
@@ -42,11 +41,10 @@ def chpw_message(
             raise Krb5Error(context, err)
 
         if message_out is NULL:
-            return ""
+            return b""
         else:
             message_len = strlen(message_out)
-            message_bytes = <bytes>message_out[:message_len]
-            return  message_bytes.decode(locale.getencoding())
+            return <bytes>message_out[:message_len]
 
     finally:
         krb5_free_string(context.raw, message_out)

--- a/src/krb5/_set_password.pyi
+++ b/src/krb5/_set_password.pyi
@@ -6,106 +6,51 @@ from krb5._context import Context
 from krb5._creds import Creds
 from krb5._principal import Principal
 
-class ADPolicyInfoProp(enum.IntFlag):
-    COMPLEX = 0x00000001
-    NO_ANON_CHANGEv = 0x00000002
-    NO_CLEAR_CHANGE = 0x00000004
-    LOCKOUT_ADMINS = 0x00000008
-    STORE_CLEARTEXT = 0x00000010
-    REFUSE_CHANGE = 0x00000020
-
-class ADPolicyInfo(typing.NamedTuple):
-    """The structure containing the reasons for failed password change attempt.
-    Should be used to inform the end user how to meet the policy requirements.
-    This is specific to Active Directory and is returned as the
-    `server_response` by :meth:`set_password()` and
-    :meth:`set_password_using_ccache()`.
-
-    When using MIT library, this structure may be encoded back to bytes and
-    passed to :meth:`chpw_message()` to obtain a human readable response.
-    With Heimdal, it is required to provide a custom implementation based
-    on the known fields below.
-
-    The structure contains the following fields:\n
-    - `properties` - Password policy bit flags (see below)
-    - `min_length` - Minimal password length
-    - `history`    - Number of passwords that this system remembers
-    - `max_age`    - Maximum password age in 100 nanosecond units
-    - `min_age`    - Minimum password age in 100 nanosecond units
-
-    The only known property flag is `COMPLEX` which means that the password must
-    meet certain character variety and not contain the user's name.
-    To convert `max_age` and `min_age` to seconds, divide them by 10,000,000.
+class SetPasswordResultCode(enum.IntEnum):
+    """Password change result constants returned by :meth:`set_password()`
+    Follow RFC 3244 with additional Microsoft extensions.
     """
 
-    properties: ADPolicyInfoProp
-    min_length: int
-    history: int
-    max_age: int
-    min_age: int
-
-    @classmethod
-    def from_bytes(cls, data: bytes) -> "ADPolicyInfo":
-        """Decode AD policy result from byte string
-
-        Args:
-            data: Serialized AD policy `server_response`
-
-        Returns:
-            ADPolicyInfo: Decoded AD policy result strcture
-
-        Raises:
-            ValueError: Invalid data length or signature not 0x0000
-        """
-    @classmethod
-    def to_bytes(cls, policy: "ADPolicyInfo") -> bytes:
-        """Reverses the `from_bytes` operation
-
-        Args:
-            policy: AD policy result structure
-
-        Returns:
-            bytes: Serialized AD policy result byte string
-        """
-
-class SetPasswordResultCode(enum.IntEnum):
-    SUCCESS = 0
-    MALFORMED = 1
-    HARDERROR = 2
-    AUTHERROR = 3
-    SOFTERROR = 4
+    SUCCESS = ...  # Success
+    MALFORMED = ...  # Malformed request
+    HARDERROR = ...  # Server error
+    AUTHERROR = ...  # Authentication error
+    SOFTERROR = ...  # Password change rejected
+    ACCESSDENIED = ...  # Microsoft extension: Not authorized
+    BAD_VERSION = ...  # Microsoft extension: Unknown RPC version
+    INITIAL_FLAG_NEEDED = ...  # Microsoft extension:
+    # The presented credentials were not obtained using a password directly
 
 class SetPasswordResult(typing.NamedTuple):
     """The result returned by :meth:`set_password()` and
     :meth:`set_password_using_ccache()`.
 
-    The `result_code` and `result_code_string` are the pure library responses:
-    - SUCCESS   (0) - Success
-    - MALFORMED (1) - Malformed request error
-    - HARDERROR (2) - Server error
-    - AUTHERROR (3) - Authentication error
-    - SOFTERROR (4) - Password change rejected
+    The `result_code` and `result_code_string` are the pure library responses.
+    See `SetPasswordResultCode` for more information.
 
     The `server_response` is a server protocol message that may contain useful
     information about password policy violations or other errors.
+    Despite RFC 3244, the server response is not standardized and may vary.
     Depending on `kpasswd` implementation, it may be returned as:\n
-    - decoded UTF-8 string (MIT KDC)
-    - decoded `ADPolicyInfo` (Active Directory Policy Information)
-    - raw bytes (if unable to decode)
+    - 30-byte binary Active Directory Policy Information
+    - UTF-8 byte string (MIT KDC, potentially Heimdal KDC)
+    - raw bytes (unknown or custom implementation)
 
-    When (and only when) the server response is exactly 30 bytes long starting
-    with `0x0000`, it is assumed to be `ADPolicyInfo`.
-    All other cases are first decoded as UTF-8 string and even if this fails,
-    the raw bytes are returned as `server_response`.
+    The trick is that Active Directory Policy Information always starts with
+    `0x0000` signature to distinguish from UTF-8.
+    So the client may try decoding the server response with either
+    :meth:`ADPolicyInfo.from_bytes()` or :meth:`bytes.decode()`.
+    And if the decoding fails with corresponding `ValueError` or
+    `UnicodeDecodeError`, the raw bytes should be analyzed.
 
     See `ADPolicyInfo` for more information.
     """
 
     result_code: SetPasswordResultCode
     """The library result code of the password change operation."""
-    result_code_string: str | bytes
-    """The decoded or byte string representation of the result code."""
-    server_response: str | ADPolicyInfo | bytes
+    result_code_string: bytes
+    """The byte string representation of the result code."""
+    server_response: bytes
     """Implementation-specific server response."""
 
 def set_password(
@@ -135,8 +80,7 @@ def set_password(
         change_password_for: `None` or the principal to set the password for.
 
     Returns:
-        SetPasswordResult: See `SetPasswordResult` for more information about
-        the return result.
+        SetPasswordResult: See `SetPasswordResult` for more information.
     """
 
 def set_password_using_ccache(
@@ -166,6 +110,5 @@ def set_password_using_ccache(
         change_password_for: `None` or the principal to set the password for.
 
     Returns:
-        SetPasswordResult: See `SetPasswordResult` for more information about
-        the return result.
+        SetPasswordResult: See `SetPasswordResult` for more information.
     """

--- a/src/krb5/_set_password.pyi
+++ b/src/krb5/_set_password.pyi
@@ -1,3 +1,4 @@
+import enum
 import typing
 
 from krb5._ccache import CCache
@@ -5,27 +6,96 @@ from krb5._context import Context
 from krb5._creds import Creds
 from krb5._principal import Principal
 
+class ADPolicyInfo(typing.NamedTuple):
+    """The structure containing the reasons for failed password change attempt.
+    Should be used to inform the end user how to meet the policy requirements.
+    This is specific to Active Directory and is returned as the `result_string`
+    by :meth:`set_password()` and :meth:`set_password_using_ccache()`. If the
+    `result_string` is exactly 30 bytes long starting with `0x0000`, it is very
+    likely to be an `ADPolicyInfo`.
+
+    The structure contains the following fields:\n
+    `properties` - Password policy flags (only `COMPLEX` has known meaning)\n
+    `min_length` - Minimal password length\n
+    `history`    - Number of passwords that this system remembers\n
+    `max_age`    - Maximum password age in 100 nanosecond units\n
+    `min_age`    - Minimum password age in 100 nanosecond units\n
+
+    The only known property is `COMPLEX` which means that the password must meet
+    certain character variety and not contain the user's name.
+    To convert `max_age` and `min_age` to seconds, divide them by 10_000_000.
+    """
+
+    class Prop(enum.IntFlag):
+        COMPLEX = 0x00000001
+        NO_ANON_CHANGEv = 0x00000002
+        NO_CLEAR_CHANGE = 0x00000004
+        LOCKOUT_ADMINS = 0x00000008
+        STORE_CLEARTEXT = 0x00000010
+        REFUSE_CHANGE = 0x00000020
+
+    SECONDS = 10000000
+    properties: "ADPolicyInfo.Prop"
+    min_length: int
+    history: int
+    max_age: int
+    min_age: int
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "ADPolicyInfo":
+        """Decode AD policy result from byte string
+
+        Args:
+            data: Serialized AD policy `result_string`
+
+        Returns:
+            ADPolicyInfo: Decoded AD policy result strcture
+
+        Raises:
+            ValueError: Invalid data length or signature not 0x0000
+        """
+
+    @classmethod
+    def to_bytes(cls, policy: "ADPolicyInfo") -> bytes:
+        """Reverses the `from_bytes` operation
+
+        Args:
+            policy: AD policy result structure
+
+        Returns:
+            bytes: Serialized AD policy result byte string
+        """
+
 class SetPasswordResult(typing.NamedTuple):
     """The result returned by :meth:`set_password()` and
     :meth:`set_password_using_ccache()`.
 
-    The `result_code` and `result_code_string` is the library response:\n
-    KRB5_KPASSWD_SUCCESS   (0) - Success\n
-    KRB5_KPASSWD_MALFORMED (1) - Malformed request error\n
-    KRB5_KPASSWD_HARDERROR (2) - Server error\n
-    KRB5_KPASSWD_AUTHERROR (3) - Authentication error\n
-    KRB5_KPASSWD_SOFTERROR (4) - Password change rejected\n
+    The `result_code` and `result_code_string` is the library response:
+    - KRB5_KPASSWD_SUCCESS   (0) - Success
+    - KRB5_KPASSWD_MALFORMED (1) - Malformed request error
+    - KRB5_KPASSWD_HARDERROR (2) - Server error
+    - KRB5_KPASSWD_AUTHERROR (3) - Authentication error
+    - KRB5_KPASSWD_SOFTERROR (4) - Password change rejected
 
     The `result_string` is a server protocol response that may contain useful
     information about password policy violations or other errors.
+    Depending on `kpasswd` implementation, it may be returned as:\n
+    - decoded UTF-8 string (MIT KDC)
+    - decoded binary structure represented by `ADPolicyInfo` (Active Directory)
+    - binary string (other implementations)
+
+    The `ADPolicyInfo` may be used directly. On MIT libraty, it may be also
+    converted back to bytes with :meth:`to_bytes()` and passed to
+    :meth:`chpw_message()` to obtain a library decoded human readable response.
+
     """
 
     result_code: int
     """The library result code of the password change operation."""
     result_code_string: bytes
     """The byte string representation of the result code."""
-    result_string: bytes
-    """Server response string"""
+    result_string: str | ADPolicyInfo | bytes
+    """Server response."""
 
 def set_password(
     context: Context,

--- a/src/krb5/_set_password.pyi
+++ b/src/krb5/_set_password.pyi
@@ -37,7 +37,6 @@ class ADPolicyInfo(typing.NamedTuple):
         LOCKOUT_ADMINS = 0x00000008
         STORE_CLEARTEXT = 0x00000010
         REFUSE_CHANGE = 0x00000020
-
     SECONDS = 10000000
     properties: "ADPolicyInfo.Prop"
     min_length: int
@@ -58,7 +57,6 @@ class ADPolicyInfo(typing.NamedTuple):
         Raises:
             ValueError: Invalid data length or signature not 0x0000
         """
-
     @classmethod
     def to_bytes(cls, policy: "ADPolicyInfo") -> bytes:
         """Reverses the `from_bytes` operation
@@ -102,7 +100,6 @@ class SetPasswordResult(typing.NamedTuple):
         HARDERROR = 2
         AUTHERROR = 3
         SOFTERROR = 4
-
     result_code: SetPasswordResult.Code
     """The library result code of the password change operation."""
     result_code_string: str | bytes

--- a/src/krb5/_set_password.pyi
+++ b/src/krb5/_set_password.pyi
@@ -6,6 +6,14 @@ from krb5._context import Context
 from krb5._creds import Creds
 from krb5._principal import Principal
 
+class ADPolicyInfoProp(enum.IntFlag):
+    COMPLEX = 0x00000001
+    NO_ANON_CHANGEv = 0x00000002
+    NO_CLEAR_CHANGE = 0x00000004
+    LOCKOUT_ADMINS = 0x00000008
+    STORE_CLEARTEXT = 0x00000010
+    REFUSE_CHANGE = 0x00000020
+
 class ADPolicyInfo(typing.NamedTuple):
     """The structure containing the reasons for failed password change attempt.
     Should be used to inform the end user how to meet the policy requirements.
@@ -30,15 +38,7 @@ class ADPolicyInfo(typing.NamedTuple):
     To convert `max_age` and `min_age` to seconds, divide them by 10,000,000.
     """
 
-    class Prop(enum.IntFlag):
-        COMPLEX = 0x00000001
-        NO_ANON_CHANGEv = 0x00000002
-        NO_CLEAR_CHANGE = 0x00000004
-        LOCKOUT_ADMINS = 0x00000008
-        STORE_CLEARTEXT = 0x00000010
-        REFUSE_CHANGE = 0x00000020
-    SECONDS = 10000000
-    properties: "ADPolicyInfo.Prop"
+    properties: ADPolicyInfoProp
     min_length: int
     history: int
     max_age: int
@@ -68,6 +68,13 @@ class ADPolicyInfo(typing.NamedTuple):
             bytes: Serialized AD policy result byte string
         """
 
+class SetPasswordResultCode(enum.IntEnum):
+    SUCCESS = 0
+    MALFORMED = 1
+    HARDERROR = 2
+    AUTHERROR = 3
+    SOFTERROR = 4
+
 class SetPasswordResult(typing.NamedTuple):
     """The result returned by :meth:`set_password()` and
     :meth:`set_password_using_ccache()`.
@@ -94,13 +101,7 @@ class SetPasswordResult(typing.NamedTuple):
     See `ADPolicyInfo` for more information.
     """
 
-    class Code(enum.IntEnum):
-        SUCCESS = 0
-        MALFORMED = 1
-        HARDERROR = 2
-        AUTHERROR = 3
-        SOFTERROR = 4
-    result_code: SetPasswordResult.Code
+    result_code: SetPasswordResultCode
     """The library result code of the password change operation."""
     result_code_string: str | bytes
     """The decoded or byte string representation of the result code."""

--- a/src/krb5/_set_password.pyi
+++ b/src/krb5/_set_password.pyi
@@ -15,18 +15,16 @@ class SetPasswordResult(typing.NamedTuple):
     KRB5_KPASSWD_HARDERROR (2) - Server error\n
     KRB5_KPASSWD_AUTHERROR (3) - Authentication error\n
     KRB5_KPASSWD_SOFTERROR (4) - Password change rejected\n
-    Note the `result_code_string` is a byte string.
 
     The `result_string` is a server protocol response that may contain useful
     information about password policy violations or other errors.
-    It is decoded as a `string` according to ``RFC 3244``
     """
 
     result_code: int
     """The library result code of the password change operation."""
     result_code_string: bytes
     """The byte string representation of the result code."""
-    result_string: str
+    result_string: bytes
     """Server response string"""
 
 def set_password(

--- a/src/krb5/_set_password.pyx
+++ b/src/krb5/_set_password.pyx
@@ -87,16 +87,16 @@ def set_password(
         if length == 0:
             result_code_bytes = b""
         else:
-            result_code_bytes = value[:length]
+            result_code_bytes = <bytes>value[:length]
 
         pykrb5_get_krb5_data(&result_string, &length, &value)
 
         if length == 0:
             result_string_bytes = b""
         else:
-            result_string_bytes = value[:length]
+            result_string_bytes = <bytes>value[:length]
 
-        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes.decode("utf-8"))
+        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes)
 
     finally:
         pykrb5_free_data_contents(context.raw, &result_code_string)
@@ -147,16 +147,16 @@ def set_password_using_ccache(
         if length == 0:
             result_code_bytes = b""
         else:
-            result_code_bytes = value[:length]
+            result_code_bytes = <bytes>value[:length]
 
         pykrb5_get_krb5_data(&result_string, &length, &value)
 
         if length == 0:
             result_string_bytes = b""
         else:
-            result_string_bytes = value[:length]
+            result_string_bytes = <bytes>value[:length]
 
-        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes.decode("utf-8"))
+        return SetPasswordResult(result_code, result_code_bytes, result_string_bytes)
 
     finally:
         pykrb5_free_data_contents(context.raw, &result_code_string)

--- a/src/krb5/_set_password.pyx
+++ b/src/krb5/_set_password.pyx
@@ -61,7 +61,7 @@ class SetPasswordResultCode(enum.IntEnum):
         value = int(value)
 
         new_member = int.__new__(cls, value)
-        new_member._name_ = f"Unknown_NameType_{str(value).replace('-', 'm')}"
+        new_member._name_ = f"Unknown_SetPasswordResultCode_{str(value).replace('-', 'm')}"
         new_member._value_ = value
         return cls._value2member_map_.setdefault(value, new_member)
 

--- a/src/krb5/_set_password.pyx
+++ b/src/krb5/_set_password.pyx
@@ -4,6 +4,7 @@ import collections
 import enum
 import struct
 import typing
+
 from krb5._exceptions import Krb5Error
 
 from krb5._ccache cimport CCache

--- a/tests/test_changepw.py
+++ b/tests/test_changepw.py
@@ -45,12 +45,12 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, empty_password.encode())
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, weak_password.encode())
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, new_password.encode())
     assert result_code == 0
@@ -91,14 +91,14 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     )
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
         ctx, cc, weak_password.encode(), princ
     )
     assert result_code != 0
     assert result_code_string.find(b"rejected") > 0
-    assert result_string.find("too short") > 0
+    assert result_string.find(b"too short") > 0
 
     (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
         ctx, cc, new_password.encode(), princ

--- a/tests/test_changepw.py
+++ b/tests/test_changepw.py
@@ -91,22 +91,22 @@ def test_chpw_message() -> None:
 
     ctx = krb5.init_context()
 
-    samples = {k: b"".join(v[0]) for k, v in adpi_tests.items()}
+    samples = {k: b"".join(v[0]) if isinstance(v, list) else b"" for k, v in adpi_tests.items()}
 
     for k, test in adpi_tests.items():
-        if len(test) > 1:
+        if isinstance(test, list) and len(test) > 1:
             phrases = test[1]
             for phrase in phrases:
                 assert krb5.chpw_message(ctx, samples[k]).find(phrase) >= 0
 
-    assert krb5.ADPolicyInfo.Prop.COMPLEX in krb5.ADPolicyInfo.from_bytes(samples["complex"]).properties
+    assert krb5.ADPolicyInfoProp.COMPLEX in krb5.ADPolicyInfo.from_bytes(samples["complex"]).properties
     assert krb5.ADPolicyInfo.from_bytes(samples["length"]).min_length == 13
     assert krb5.ADPolicyInfo.from_bytes(samples["history"]).history == 9
-    assert krb5.ADPolicyInfo.from_bytes(samples["age"]).min_age == 2 * 86400 * krb5.ADPolicyInfo.SECONDS
+    assert krb5.ADPolicyInfo.from_bytes(samples["age"]).min_age == 2 * 86400 * 10_000_000
     assert krb5.ADPolicyInfo.from_bytes(samples["combined"]).min_length == 5
     assert krb5.ADPolicyInfo.from_bytes(samples["combined"]).history == 13
-    assert krb5.ADPolicyInfo.from_bytes(samples["combined"]).min_age == 1 * 86400 * krb5.ADPolicyInfo.SECONDS
-    assert krb5.ADPolicyInfo.Prop.COMPLEX in krb5.ADPolicyInfo.from_bytes(samples["combined"]).properties
+    assert krb5.ADPolicyInfo.from_bytes(samples["combined"]).min_age == 1 * 86400 * 10_000_000
+    assert krb5.ADPolicyInfoProp.COMPLEX in krb5.ADPolicyInfo.from_bytes(samples["combined"]).properties
     assert 0x80000000 & krb5.ADPolicyInfo.from_bytes(samples["unknown"]).properties != 0
 
 
@@ -149,21 +149,21 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     assert isinstance(creds, krb5.Creds)
 
     (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, empty_password.encode())
-    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert result_code == krb5.SetPasswordResultCode.SOFTERROR
     assert isinstance(result_code_string, str)
     assert result_code_string.find("rejected") > 0
     assert isinstance(server_response, str)
     assert server_response.find("too short") > 0
 
     (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, weak_password.encode())
-    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert result_code == krb5.SetPasswordResultCode.SOFTERROR
     assert isinstance(result_code_string, str)
     assert result_code_string.find("rejected") > 0
     assert isinstance(server_response, str)
     assert server_response.find("too short") > 0
 
     (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, new_password.encode())
-    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
+    assert result_code == krb5.SetPasswordResultCode.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password.encode())
     assert isinstance(creds, krb5.Creds)
@@ -173,7 +173,7 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     (result_code, result_code_string, server_response) = krb5.set_password(
         ctx, admin_creds, new_password2.encode(), change_password_for=princ
     )
-    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
+    assert result_code == krb5.SetPasswordResultCode.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password2.encode())
     assert isinstance(creds, krb5.Creds)
@@ -199,7 +199,7 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, empty_password.encode(), princ
     )
-    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert result_code == krb5.SetPasswordResultCode.SOFTERROR
     assert isinstance(result_code_string, str)
     assert result_code_string.find("rejected") > 0
     assert isinstance(server_response, str)
@@ -208,7 +208,7 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, weak_password.encode(), princ
     )
-    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert result_code == krb5.SetPasswordResultCode.SOFTERROR
     assert isinstance(result_code_string, str)
     assert result_code_string.find("rejected") > 0
     assert isinstance(server_response, str)
@@ -217,7 +217,7 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, new_password.encode(), princ
     )
-    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
+    assert result_code == krb5.SetPasswordResultCode.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password.encode())
     assert isinstance(creds, krb5.Creds)
@@ -233,7 +233,7 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, admin_cc, new_password2.encode(), change_password_for=princ
     )
-    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
+    assert result_code == krb5.SetPasswordResultCode.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password2.encode())
     assert isinstance(creds, krb5.Creds)

--- a/tests/test_changepw.py
+++ b/tests/test_changepw.py
@@ -148,30 +148,32 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     creds = krb5.get_init_creds_password(ctx, princ, opt, old_password.encode(), in_tkt_service=b"kadmin/changepw")
     assert isinstance(creds, krb5.Creds)
 
-    (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, empty_password.encode())
-    assert result_code != 0
-    assert result_code_string.find(b"rejected") > 0
-    assert isinstance(result_string, str)
-    assert result_string.find("too short") > 0
+    (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, empty_password.encode())
+    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert isinstance(result_code_string, str)
+    assert result_code_string.find("rejected") > 0
+    assert isinstance(server_response, str)
+    assert server_response.find("too short") > 0
 
-    (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, weak_password.encode())
-    assert result_code != 0
-    assert result_code_string.find(b"rejected") > 0
-    assert isinstance(result_string, str)
-    assert result_string.find("too short") > 0
+    (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, weak_password.encode())
+    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert isinstance(result_code_string, str)
+    assert result_code_string.find("rejected") > 0
+    assert isinstance(server_response, str)
+    assert server_response.find("too short") > 0
 
-    (result_code, result_code_string, result_string) = krb5.set_password(ctx, creds, new_password.encode())
-    assert result_code == 0
+    (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, new_password.encode())
+    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password.encode())
     assert isinstance(creds, krb5.Creds)
     assert creds.client.name == princ.name
 
     # set_password for other principal using admin creds
-    (result_code, result_code_string, result_string) = krb5.set_password(
+    (result_code, result_code_string, server_response) = krb5.set_password(
         ctx, admin_creds, new_password2.encode(), change_password_for=princ
     )
-    assert result_code == 0
+    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password2.encode())
     assert isinstance(creds, krb5.Creds)
@@ -194,26 +196,28 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     krb5.cc_initialize(ctx, cc, princ)
     krb5.cc_store_cred(ctx, cc, creds)
 
-    (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
+    (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, empty_password.encode(), princ
     )
-    assert result_code != 0
-    assert result_code_string.find(b"rejected") > 0
-    assert isinstance(result_string, str)
-    assert result_string.find("too short") > 0
+    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert isinstance(result_code_string, str)
+    assert result_code_string.find("rejected") > 0
+    assert isinstance(server_response, str)
+    assert server_response.find("too short") > 0
 
-    (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
+    (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, weak_password.encode(), princ
     )
-    assert result_code != 0
-    assert result_code_string.find(b"rejected") > 0
-    assert isinstance(result_string, str)
-    assert result_string.find("too short") > 0
+    assert result_code == krb5.SetPasswordResult.Code.SOFTERROR
+    assert isinstance(result_code_string, str)
+    assert result_code_string.find("rejected") > 0
+    assert isinstance(server_response, str)
+    assert server_response.find("too short") > 0
 
-    (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
+    (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, new_password.encode(), princ
     )
-    assert result_code == 0
+    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password.encode())
     assert isinstance(creds, krb5.Creds)
@@ -226,10 +230,10 @@ def test_set_password(realm: k5test.K5Realm) -> None:
     krb5.cc_store_cred(ctx, admin_cc, admin_creds)
 
     # set_password for other principal using admin ccache
-    (result_code, result_code_string, result_string) = krb5.set_password_using_ccache(
+    (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, admin_cc, new_password2.encode(), change_password_for=princ
     )
-    assert result_code == 0
+    assert result_code == krb5.SetPasswordResult.Code.SUCCESS
 
     creds = krb5.get_init_creds_password(ctx, princ, opt, new_password2.encode())
     assert isinstance(creds, krb5.Creds)

--- a/tests/test_changepw.py
+++ b/tests/test_changepw.py
@@ -97,7 +97,8 @@ def test_chpw_message() -> None:
         if isinstance(test, list) and len(test) > 1:
             phrases = test[1]
             for phrase in phrases:
-                assert krb5.chpw_message(ctx, samples[k]).find(phrase) >= 0
+                message = krb5.chpw_message(ctx, samples[k])
+                assert message.decode().find(phrase) >= 0
 
     assert krb5.ADPolicyInfoProp.COMPLEX in krb5.ADPolicyInfo.from_bytes(samples["complex"]).properties
     assert krb5.ADPolicyInfo.from_bytes(samples["length"]).min_length == 13
@@ -150,17 +151,13 @@ def test_set_password(realm: k5test.K5Realm) -> None:
 
     (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, empty_password.encode())
     assert result_code == krb5.SetPasswordResultCode.SOFTERROR
-    assert isinstance(result_code_string, str)
-    assert result_code_string.find("rejected") > 0
-    assert isinstance(server_response, str)
-    assert server_response.find("too short") > 0
+    assert result_code_string.find(b"rejected") > 0
+    assert server_response.find(b"too short") > 0
 
     (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, weak_password.encode())
     assert result_code == krb5.SetPasswordResultCode.SOFTERROR
-    assert isinstance(result_code_string, str)
-    assert result_code_string.find("rejected") > 0
-    assert isinstance(server_response, str)
-    assert server_response.find("too short") > 0
+    assert result_code_string.find(b"rejected") > 0
+    assert server_response.find(b"too short") > 0
 
     (result_code, result_code_string, server_response) = krb5.set_password(ctx, creds, new_password.encode())
     assert result_code == krb5.SetPasswordResultCode.SUCCESS
@@ -200,19 +197,15 @@ def test_set_password(realm: k5test.K5Realm) -> None:
         ctx, cc, empty_password.encode(), princ
     )
     assert result_code == krb5.SetPasswordResultCode.SOFTERROR
-    assert isinstance(result_code_string, str)
-    assert result_code_string.find("rejected") > 0
-    assert isinstance(server_response, str)
-    assert server_response.find("too short") > 0
+    assert result_code_string.find(b"rejected") > 0
+    assert server_response.find(b"too short") > 0
 
     (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, weak_password.encode(), princ
     )
     assert result_code == krb5.SetPasswordResultCode.SOFTERROR
-    assert isinstance(result_code_string, str)
-    assert result_code_string.find("rejected") > 0
-    assert isinstance(server_response, str)
-    assert server_response.find("too short") > 0
+    assert result_code_string.find(b"rejected") > 0
+    assert server_response.find(b"too short") > 0
 
     (result_code, result_code_string, server_response) = krb5.set_password_using_ccache(
         ctx, cc, new_password.encode(), princ


### PR DESCRIPTION
The `result_string` returned from `kpasswd` service by `krb5_set_password()` family is a non-documented binary sequence that may or may not be a human readable string. However it is mandatory to clearly inform of the end user what requirements does the system provide to conduct a successful password change operation. For example, system may remember last 24 used passwords and thus decline operation. Or the minimum password age may be 1 day. Etc, etc.

The only way to obtain such information by client is to analyze the mentioned `result_string`.
Based on MIT library source code it appears that at least two cases deserve special attention:

1. UTF8-compatible string returned by MIT and other non-MS implementations, human readable.
2. 30-byte binary structure starting with `0x0000` (to avoid confusing with UTF8), returned by Active Directory that contains machine-encoded rules for password validity, referred as `ADPolicyInfo`.
3. All other responses are returned as raw bytes.

MIT library contains a dedicated function `krb5_chpw_message()` to decode the `ADPolicyInfo`, in a locale-sensitive fashion. With Heimdal, it is required to analyze the `ADPolicyInfo` and generate the response in the client code.

This PR addresses above mentioned cases providing "best efforts" decoding of the `result_string` and `chpw_message()` interface to MIT library decoder. Additional enums where introduced ~~as nested classes~~ for status codes and `ADPolicyInfo` binary flags. Also, the`result_code_string` pure library response is decoded as string when possible.

The implementation and unit test protocols are based on MIT `decode_ad_policy_info()` internal function and according tests from `test_chpw_message.c`. 