### PR TITLE
Update min Python to 3.8 and added 3.13 wheel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
         os:
         - macOS-12
         version:
-        - cp37-macosx_x86_64
         - cp38-macosx_x86_64
         - cp38-macosx_arm64
         - cp39-macosx_x86_64
@@ -66,6 +65,8 @@ jobs:
         - cp311-macosx_arm64
         - cp312-macosx_x86_64
         - cp312-macosx_arm64
+        - cp313-macosx_x86_64
+        - cp313-macosx_arm64
 
     steps:
     - uses: actions/download-artifact@v4
@@ -81,7 +82,7 @@ jobs:
         rm krb5-*.tar.gz
 
     - name: build wheel
-      uses: pypa/cibuildwheel@v2.16.5
+      uses: pypa/cibuildwheel@v2.21.0
       env:
         CIBW_ARCHS: all
         CIBW_TEST_SKIP: '*_arm64'
@@ -107,12 +108,12 @@ jobs:
         - ubuntu-latest
         - macOS-12
         python-version:
-        - 3.7
         - 3.8
         - 3.9
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13.0-rc.2'
         provider:
         - mit
         - heimdal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.7.0 - TBD
 
+* Require Python 3.8 or newer (dropped 3.7)
+* Added Python 3.13 wheel for macOS
 * Added password management APIs
   * [krb5_set_password](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_set_password.html)
   * [krb5_set_password_using_ccache](https://web.mit.edu/kerberos/krb5-latest/doc/appdev/refs/api/krb5_set_password_using_ccache.html)

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Development Status :: 4 - Beta
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -28,7 +27,7 @@ package_dir =
     =src
 packages = find:
 include_package_data = True
-python_requires = >= 3.7
+python_requires = >= 3.8
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Updates the minimum Python version to 3.8 and adds the 3.13 wheel to the CI build and test cycle.