### PR TITLE
Fix Cython 0.29.x build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-        - macOS-12
+        - macOS-latest
         version:
         - cp38-macosx_x86_64
         - cp38-macosx_arm64
@@ -82,10 +82,9 @@ jobs:
         rm krb5-*.tar.gz
 
     - name: build wheel
-      uses: pypa/cibuildwheel@v2.21.2
+      uses: pypa/cibuildwheel@v2.21.3
       env:
         CIBW_ARCHS: all
-        CIBW_TEST_SKIP: '*_arm64'
         CIBW_BUILD: ${{ matrix.version }}
         CIBW_BUILD_VERBOSITY: 1
 
@@ -94,10 +93,33 @@ jobs:
         path: ./wheelhouse/*.whl
         name: artifact-wheel-${{ matrix.version }}
 
+  build_cython_0_29:
+    name: build cython 0.29.x
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+
+    - name: build cython 0.29
+      run: |
+        sudo /bin/bash -c 'source ./build_helpers/lib.sh; lib::setup::system_requirements'
+
+        python -m pip install build
+        echo 'Cython<3.0.0' > constraints.txt
+        PIP_CONSTRAINT=constraints.txt python -m build \
+            --sdist \
+            --wheel \
+            --installer pip \
+            --verbose
+
   test:
     name: test
     needs:
     - build_sdist
+    - build_cython_0_29
     - build_wheels
 
     runs-on: ${{ matrix.os }}
@@ -106,20 +128,20 @@ jobs:
       matrix:
         os:
         - ubuntu-latest
-        - macOS-12
+        - macOS-latest
         python-version:
         - 3.8
         - 3.9
         - '3.10'
         - '3.11'
         - '3.12'
-        - '3.13.0-rc.3'
+        - '3.13'
         provider:
         - mit
         - heimdal
 
         exclude:
-        - os: macOS-12
+        - os: macOS-latest
           provider: mit
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.1 - TBD
+
+* Fix up Cython 0.29.x support when building the library
+
 ## 0.7.0 - 2024-10-03
 
 * Require Python 3.8 or newer (dropped 3.7)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = krb5
-version = 0.7.0
+version = 0.7.1
 url = https://github.com/jborean93/pykrb5
 author = Jordan Borean
 author_email = jborean93@gmail.com

--- a/src/krb5/_set_password.pyi
+++ b/src/krb5/_set_password.pyi
@@ -1,3 +1,8 @@
+# Copyright: (c) 2024 Jordan Borean (@jborean93) <jborean93@gmail.com>
+# MIT License (see LICENSE or https://opensource.org/licenses/MIT)
+
+from __future__ import annotations
+
 import enum
 import typing
 
@@ -57,7 +62,7 @@ def set_password(
     context: Context,
     creds: Creds,
     newpw: bytes,
-    change_password_for: typing.Optional[Principal] = None,
+    change_password_for: Principal | None = None,
 ) -> SetPasswordResult:
     """Set a password for a principal using specified credentials.
 
@@ -87,7 +92,7 @@ def set_password_using_ccache(
     context: Context,
     ccache: CCache,
     newpw: bytes,
-    change_password_for: typing.Optional[Principal] = None,
+    change_password_for: Principal | None = None,
 ) -> SetPasswordResult:
     """Set a password for a principal using cached credentials.
 

--- a/src/krb5/_set_password.pyx
+++ b/src/krb5/_set_password.pyx
@@ -74,7 +74,7 @@ def set_password(
     Context context not None,
     Creds creds not None,
     const unsigned char[:] newpw not None,
-    change_password_for: typing.Optional[Principal] = None,
+    Principal change_password_for = None,
 ) -> SetPasswordResult:
     cdef krb5_error_code err = 0
     cdef int result_code
@@ -134,7 +134,7 @@ def set_password_using_ccache(
     Context context not None,
     CCache ccache not None,
     const unsigned char[:] newpw not None,
-    change_password_for: typing.Optional[Principal] = None,
+    Principal change_password_for = None,
 ) -> SetPasswordResult:
     cdef krb5_error_code err = 0
     cdef int result_code


### PR DESCRIPTION
Fix bug for Cython 0.29.x that broke it from generating valid C code on that older version. Also adds a basic test in CI to ensure the build doesn't fail again.

Fixes: https://github.com/jborean93/pykrb5/issues/57